### PR TITLE
Add config directory to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include MANIFEST.in
 include README.md
+recursive-include config *
 recursive-include colin *
 recursive-include docs *
 recursive-include examples *


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

Config directory has to be included in MANIFEST.in file.