### PR TITLE
Print checks

### DIFF
--- a/colin/checks/abstract/abstract_check.py
+++ b/colin/checks/abstract/abstract_check.py
@@ -13,6 +13,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+import json
+
+from six import iteritems
+
 
 class AbstractCheck(object):
 
@@ -27,3 +31,50 @@ class AbstractCheck(object):
 
     def check(self, target):
         pass
+
+    def __str__(self):
+        return "{}\n" \
+               "   -> {}\n" \
+               "   -> {}\n" \
+               "   -> {}\n" \
+               "   -> {}\n" \
+               "   -> {}\n".format(self.name,
+                                   self.message,
+                                   self.description,
+                                   self.reference_url,
+                                   self.tags,
+                                   self.severity)
+
+    @property
+    def json(self):
+        """
+        Get json representation of the check
+
+        :return: dict (str -> obj)
+        """
+        return {
+            'name': self.name,
+            'message': self.message,
+            'description': self.description,
+            'reference_url': self.reference_url,
+            'tags': self.tags,
+            'severity': self.severity,
+        }
+
+    @staticmethod
+    def json_from_all_checks(checks):
+        result_json = {}
+        for (group, group_checks) in iteritems(checks):
+
+            result_list = []
+            for check in group_checks:
+                result_list.append(check.json)
+
+            result_json[group] = result_list
+        return result_json
+
+    @staticmethod
+    def save_checks_to_json(file, checks):
+        json.dump(obj=AbstractCheck.json_from_all_checks(checks=checks),
+                  fp=file,
+                  indent=4)

--- a/colin/core/colin.py
+++ b/colin/core/colin.py
@@ -41,15 +41,51 @@ def run(name_of_target, group=None, severity=None, tags=None, config_name=None, 
     logger.debug("Checking started.")
     target = Target(name=name_of_target,
                     logging_level=logging_level)
-    config = Config(config_name=config_name,
-                    config_file=config_file)
-    checks_to_run = config.get_checks(group=group,
-                                      severity=severity,
-                                      tags=tags,
-                                      target_type=target.target_type)
+    checks_to_run = _get_checks(target=target,
+                                group=group,
+                                severity=severity,
+                                tags=tags,
+                                config_name=config_name,
+                                config_file=config_file)
     result = go_through_checks(target=target,
                                checks=checks_to_run)
     return result
+
+
+def get_checks(name_of_target, group=None, severity=None, tags=None, config_name=None, config_file=None,
+               logging_level=logging.WARNING):
+    """
+    Get the sanity checks for the target.
+
+    :param name_of_target: str (name of the container or image, dockerfile will be added in the future)
+    :param group: str (name of the folder with group of checks, if None, all of them will be checked.)
+    :param severity: str (if not None, only those checks will be run -- optional x required x warn ...)
+    :param tags: list of str (if not None, the checks will be filtered by tags.)
+    :param config_name: str (e.g. fedora; if None, default would be used)
+    :param config_file: str (path)
+    :param logging_level: logging level (default logging.WARNING)
+    :return: list of groups of checks
+    """
+    _set_logging(level=logging_level)
+    logger.debug("Finding checks started.")
+    target = Target(name=name_of_target,
+                    logging_level=logging_level)
+    return _get_checks(target=target,
+                       group=group,
+                       severity=severity,
+                       tags=tags,
+                       config_name=config_name,
+                       config_file=config_file)
+
+
+def _get_checks(target, group=None, severity=None, tags=None, config_name=None, config_file=None):
+    logger.debug("Checking started.")
+    config = Config(config_name=config_name,
+                    config_file=config_file)
+    return config.get_checks(group=group,
+                             severity=severity,
+                             tags=tags,
+                             target_type=target.target_type)
 
 
 def _set_logging(


### PR DESCRIPTION
Add support for printing checks without running them.
- CLI option  `--print-checks`
- compatible with `--json` option
 
```
Usage: colin.py [OPTIONS] TARGET

Options:
  -c, --config [redhat|fedora]  Select a predefined configuration.
  -f, --config-file FILENAME    Path to a file to use for validation (by
                                default they are placed in /usr/share/colin).
  --debug                       Enable debugging mode (debugging logs, full
                                tracebacks).
  --json FILENAME               File to save the output as json to.
  -s, --stat                    Print statistics instead of full results.
  --print-checks                Print the checks without running them.
  -v, --verbose                 Verbose mode.
  -h, --help                    Show this message and exit.
```

```json
{
    "labels": [
        {
            "name": "maintainer_label_required",
            "message": "Label 'maintainer' has to be specified.",
            "description": "The name and email of the maintainer (usually the submitter).",
            "reference_url": "https://fedoraproject.org/wiki/Container:Guidelines#LABELS",
            "tags": [
                "maintainer",
                "label",
                "required"
            ],
            "severity": "required"
        }
    ]
}
```