### PR TITLE
[README] how to make list-[checks|rulesets] work from git

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ Commands:
   list-rulesets  List available rulesets.
 ```
 
+`list-checks` and `list-rulesets` commands expect rulesets directory either in
+`/usr/local/share/colin/` or in `$HOME/.local/share/colin/` and may fail if it's
+not there. To make them work directly from git repo make a symlink:
+`ln -s $(pwd)/rulesets/ ~/.local/share/colin/rulesets`
+
 We can now run the analysis:
 
 ```


### PR DESCRIPTION
When one runs `list-checks -r` or `list-rulesets` directly from git repo one gets:

```
File "/home/jpopelka/git/user-cont/colin/colin/core/ruleset/ruleset.py", line 208, in get_ruleset_directory
    raise ColinRulesetException(msg)
colin.core.exceptions.ColinRulesetException: Ruleset directory cannot be found.
```

We can either hack `get_ruleset_directory()` to discover also local (in git repo) `rulesets/` or add a notice into README.