### PR TITLE
Implementation of the most useful output

### DIFF
--- a/colin/checks/labels/distribution-scope.py
+++ b/colin/checks/labels/distribution-scope.py
@@ -4,11 +4,12 @@ from colin.checks.abstract.labels import LabelCheck
 class DescriptionScopeLabelCheck(LabelCheck):
 
     def __init__(self):
-        super(self.__class__, self).__init__(name="distribution-scope_label",
-                                             message="Label 'distribution-scope' has to be specified.",
-                                             description="Scope of intended distribution of the image. (private/authoritative-source-only/restricted/public)",
-                                             reference_url="https://github.com/projectatomic/ContainerApplicationGenericLabels",
-                                             tags=["distribution-scope", "label", "required"],
-                                             label="distribution-scope",
-                                             required=True,
-                                             value_regex=None)
+        super(self.__class__, self) \
+            .__init__(name="distribution-scope_label",
+                      message="Label 'distribution-scope' has to be specified.",
+                      description="Scope of intended distribution of the image. (private/authoritative-source-only/restricted/public)",
+                      reference_url="https://github.com/projectatomic/ContainerApplicationGenericLabels",
+                      tags=["distribution-scope", "label", "required"],
+                      label="distribution-scope",
+                      required=True,
+                      value_regex=None)

--- a/colin/checks/labels/release.py
+++ b/colin/checks/labels/release.py
@@ -4,11 +4,12 @@ from colin.checks.abstract.labels import LabelCheck
 class ReleaseLabelCheck(LabelCheck):
 
     def __init__(self):
-        LabelCheck.__init__(name="release_label",
-                            message="Label 'release' has to be specified.",
-                            description="Release Number for this version.",
-                            reference_url="https://fedoraproject.org/wiki/Container:Guidelines#LABELS",
-                            tags=["release", "label", "required"],
-                            label="release",
-                            required=True,
-                            value_regex=None)
+        super(self.__class__, self) \
+            .__init__(name="release_label",
+                      message="Label 'release' has to be specified.",
+                      description="Release Number for this version.",
+                      reference_url="https://fedoraproject.org/wiki/Container:Guidelines#LABELS",
+                      tags=["release", "label", "required"],
+                      label="release",
+                      required=True,
+                      value_regex=None)

--- a/colin/checks/labels/url.py
+++ b/colin/checks/labels/url.py
@@ -4,12 +4,13 @@ from colin.checks.abstract.labels import LabelCheck
 class UrlLabelCheck(LabelCheck):
 
     def __init__(self):
-        LabelCheck.__init__(name="url_label",
-                            message="Label 'url' has to be specified.",
-                            description="A URL where the user can find more information about the image.",
-                            reference_url="https://fedoraproject.org/wiki/Container:Guidelines#LABELS",
-                            tags=["url", "label", "required"],
-                            label="url",
-                            required=True,
-                            value_regex=None)
+        super(self.__class__, self) \
+            .__init__(name="url_label",
+                      message="Label 'url' has to be specified.",
+                      description="A URL where the user can find more information about the image.",
+                      reference_url="https://fedoraproject.org/wiki/Container:Guidelines#LABELS",
+                      tags=["url", "label", "required"],
+                      label="url",
+                      required=True,
+                      value_regex=None)
         # TODO: Check the format for RHEL

--- a/colin/checks/result.py
+++ b/colin/checks/result.py
@@ -18,7 +18,8 @@ import json
 
 from six import iteritems
 
-from ..core.constant import FAILED, OPTIONAL, PASSED, REQUIRED, WARNING
+from ..core.constant import (COLOURS, FAILED, OPTIONAL, OUTPUT_CHARS, PASSED,
+                             REQUIRED, WARNING)
 
 
 class CheckResult(object):
@@ -43,9 +44,8 @@ class CheckResult(object):
         return status_ok if self.ok else status_nok
 
     def __str__(self):
-        return "{}:{}:{}".format("ok " if self.ok else "nok",
-                                 self.status,
-                                 self.check_name)
+        return "{}:{}".format(self.status,
+                              self.message)
 
 
 class DockerfileCheckResult(CheckResult):
@@ -150,3 +150,62 @@ class CheckResults(object):
         for r in results:
             self._generated_result[group].append(r)
             yield r
+
+    def generate_pretty_output(self, stat, verbose, output_function):
+        """
+        Send the formated to the provided function
+
+        :param stat: if True print stat instead of full output
+        :param verbose: bool
+        :param output_function: function to send output to
+        """
+        for group, check_results in self.results:
+
+            group_title_printed = False
+            for r in check_results:
+
+                if not group_title_printed:
+                    output_function("{}:".format(group.upper()),
+                                    nl=not stat)
+                    group_title_printed = True
+
+                if stat:
+                    output_function(OUTPUT_CHARS[r.status],
+                                    fg=COLOURS[r.status],
+                                    nl=False)
+                else:
+                    output_function(str(r), fg=COLOURS[r.status])
+                    if verbose:
+                        output_function("  -> {}\n"
+                                        "  -> {}".format(r.description,
+                                                         r.reference_url),
+                                        fg=COLOURS[r.status])
+
+            if group_title_printed and stat:
+                output_function("")
+
+    def get_pretty_string(self, stat, verbose):
+        """
+        Pretty string representation of the results
+
+        :param stat: bool
+        :param verbose: bool
+        :return: str
+        """
+        pretty_output = _PrettyOutputToStr()
+        self.generate_pretty_output(stat=stat,
+                                    verbose=verbose,
+                                    output_function=pretty_output.save_output)
+        return pretty_output.result
+
+
+class _PrettyOutputToStr(object):
+
+    def __init__(self):
+        self.result = ""
+
+    def save_output(self, text=None, fg=None, nl=True):
+        text = text or ""
+        self.result += text
+        if nl:
+            self.result += "\n"

--- a/colin/checks/result.py
+++ b/colin/checks/result.py
@@ -16,6 +16,7 @@
 
 import json
 
+import six
 from six import iteritems
 
 from ..core.constant import (COLOURS, FAILED, OPTIONAL, OUTPUT_CHARS, PASSED,
@@ -127,6 +128,14 @@ class CheckResults(object):
         else:
             return self._group_generator()
 
+    @property
+    def statistics(self):
+        result = {}
+        for r in self.all_results:
+            result.setdefault(r.status, 0)
+            result[r.status] += 1
+        return result
+
     def _group_generator(self):
         """
         Forward original generator of result groups, but saves the value for the future use.
@@ -183,6 +192,12 @@ class CheckResults(object):
 
             if group_title_printed and stat:
                 output_function("")
+
+        if not stat or verbose:
+            output_function("")
+            for status, count in six.iteritems(self.statistics):
+                output_function("{}:{} ".format(status, count), nl=False)
+            output_function("")
 
     def get_pretty_string(self, stat, verbose):
         """

--- a/colin/cli/colin.py
+++ b/colin/cli/colin.py
@@ -53,9 +53,11 @@ def cli():
               help="File to save the output as json to.")
 @click.option('--stat', '-s', is_flag=True,
               help="Print statistics instead of full results.")
+@click.option('--tag', '-t', multiple=True, type=click.STRING,
+              help="Filter checks with the tag.")
 @click.option('--verbose', '-v', is_flag=True,
               help="Verbose mode.")
-def check(target, ruleset, ruleset_file, debug, json, stat, verbose):
+def check(target, ruleset, ruleset_file, debug, json, stat, tag, verbose):
     """
     Check the image/container/dockerfile (default).
     """
@@ -74,7 +76,8 @@ def check(target, ruleset, ruleset_file, debug, json, stat, verbose):
         results = run(target=target,
                       ruleset_name=ruleset,
                       ruleset_file=ruleset_file,
-                      logging_level=log_level)
+                      logging_level=log_level,
+                      tags=tag)
         _print_results(results=results, stat=stat, verbose=verbose)
 
         if json:
@@ -104,9 +107,11 @@ def check(target, ruleset, ruleset_file, debug, json, stat, verbose):
               help="Enable debugging mode (debugging logs, full tracebacks).")
 @click.option('--json', type=click.File(mode='w'),
               help="File to save the output as json to.")
+@click.option('--tag', '-t', multiple=True, type=click.STRING,
+              help="Filter checks with the tag.")
 @click.option('--verbose', '-v', is_flag=True,
               help="Verbose mode.")
-def list_checks(ruleset, ruleset_file, debug, json, verbose):
+def list_checks(ruleset, ruleset_file, debug, json, tag, verbose):
     """
     Print the checks.
     """
@@ -125,7 +130,8 @@ def list_checks(ruleset, ruleset_file, debug, json, verbose):
 
         checks = get_checks(ruleset_name=ruleset,
                             ruleset_file=ruleset_file,
-                            logging_level=log_level)
+                            logging_level=log_level,
+                            tags=tag)
         _print_checks(checks=checks)
 
         if json:

--- a/colin/cli/colin.py
+++ b/colin/cli/colin.py
@@ -66,7 +66,7 @@ def check(target, ruleset, ruleset_file, debug, json, stat, verbose):
         raise click.BadOptionUsage("Options '--debug' and '--verbose' cannot be used together.")
 
     try:
-        if not (debug or verbose):
+        if not debug:
             logger.disabled = True
 
         log_level = _get_log_level(debug=debug,

--- a/colin/cli/colin.py
+++ b/colin/cli/colin.py
@@ -21,7 +21,6 @@ from six import iteritems
 
 from ..checks.abstract.abstract_check import AbstractCheck
 from ..core.colin import get_checks, run
-from ..core.constant import COLOURS, OUTPUT_CHARS
 from ..core.exceptions import ColinException
 from ..core.ruleset.ruleset import get_rulesets
 from ..version import __version__
@@ -140,39 +139,17 @@ cli.add_command(list_rulesets)
 cli.set_default_command(check)
 
 
-def _print_results(results, stat=False):
+def _print_results(results, stat=False, verbose=False):
     """
     Prints the results to the stdout
 
+    :type verbose: bool
     :param results: generator of group results
     :param stat: if True print stat instead of full output
     """
-    for group, check_results in results.results:
-
-        group_title_printed = False
-        for r in check_results:
-
-            if not group_title_printed:
-                click.secho("{}:".format(group.upper()),
-                            nl=not stat)
-                group_title_printed = True
-
-            if stat:
-                click.secho(OUTPUT_CHARS[r.status],
-                            fg=COLOURS[r.status],
-                            nl=False)
-            else:
-                click.secho(str(r), fg=COLOURS[r.status])
-                if not r.ok:
-                    click.secho("   -> {}\n"
-                                "   -> {}\n"
-                                "   -> {}".format(r.message,
-                                                  r.description,
-                                                  r.reference_url),
-                                fg=COLOURS[r.status])
-
-        if group_title_printed and stat:
-            click.echo()
+    results.generate_pretty_output(stat=stat,
+                                   verbose=verbose,
+                                   output_function=click.secho)
 
 
 def _print_checks(checks):

--- a/colin/cli/colin.py
+++ b/colin/cli/colin.py
@@ -26,7 +26,7 @@ from ..core.ruleset.ruleset import get_rulesets
 from ..version import __version__
 from .default_group import DefaultGroup
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("colin.cli")
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
@@ -66,13 +66,16 @@ def check(target, ruleset, ruleset_file, debug, json, stat, verbose):
         raise click.BadOptionUsage("Options '--debug' and '--verbose' cannot be used together.")
 
     try:
+        if not (debug or verbose):
+            logger.disabled = True
 
+        log_level = _get_log_level(debug=debug,
+                                   verbose=verbose)
         results = run(target=target,
                       ruleset_name=ruleset,
                       ruleset_file=ruleset_file,
-                      logging_level=_get_log_level(debug=debug,
-                                                   verbose=verbose))
-        _print_results(results=results, stat=stat)
+                      logging_level=log_level)
+        _print_results(results=results, stat=stat, verbose=verbose)
 
         if json:
             results.save_json_to_file(file=json)
@@ -169,7 +172,7 @@ def _get_log_level(debug, verbose):
     if debug:
         return logging.DEBUG
     if verbose:
-        return logging.INFO
+        return logging.WARNING
     return logging.WARNING
 
 

--- a/colin/core/colin.py
+++ b/colin/core/colin.py
@@ -113,5 +113,4 @@ def _set_logging(
 
     formatter = logging.Formatter(format, date_format)
     handler.setFormatter(formatter)
-    logger.handlers.clear()
     logger.addHandler(handler)

--- a/colin/core/colin.py
+++ b/colin/core/colin.py
@@ -113,4 +113,5 @@ def _set_logging(
 
     formatter = logging.Formatter(format, date_format)
     handler.setFormatter(formatter)
+    logger.handlers.clear()
     logger.addHandler(handler)

--- a/colin/core/constant.py
+++ b/colin/core/constant.py
@@ -18,9 +18,9 @@ RULESET_DIRECTORY = "share/colin/rulesets/"
 JSON = ".json"
 MODULE_NAME_IMPORTED_CHECKS = "colin.checks.imported"
 
-PASSED = "passed"
-FAILED = "failed"
-WARNING = "warning"
+PASSED = "pass"
+FAILED = "fail"
+WARNING = "warn"
 
 REQUIRED = "required"
 OPTIONAL = "optional"

--- a/colin/core/ruleset/ruleset.py
+++ b/colin/core/ruleset/ruleset.py
@@ -131,14 +131,14 @@ class Ruleset(object):
             check_instance.severity = severity
             if not is_compatible(target_type=target_type, check_instance=check_instance):
                 logger.debug(
-                    "Check {} not compatible with the target type: {}".format(check_instance.name, target_type.name))
+                    "Check '{}' not compatible with the target type: {}".format(check_instance.name, target_type.name))
                 continue
 
             if tags:
-                for t in tags:
-                    if t not in check_instance.tags:
-                        logger.debug("Check not passed the tag control: {}".format(t))
-                        continue
+                if not set(tags) < set(check_instance.tags):
+                    logger.debug("Check '{}' not passed the tag control: {}".format(check_instance.name,
+                                                                                  tags))
+                    continue
             result.append(check_instance)
             logger.debug("Check instance {} added.".format(check_instance.name))
 


### PR DESCRIPTION
- Better output.
- Allow saving output to the string.
- Handle errors in the subcommands.
- Turn off the logs when no-debug.
- Print the statistics after the results.
- Allow filtering of the checks with the tags (e.g. `-t label -t maintainer`) (in `list-checks` and `check`)

----
- Correct super calls in some checks.

Resolves  #65 