### PR TITLE
Simplify checks

### DIFF
--- a/colin/checks/abstract/dockerfile.py
+++ b/colin/checks/abstract/dockerfile.py
@@ -106,7 +106,7 @@ class InstructionCountCheck(DockerfileCheck):
 class DockerfileLabelCheck(DockerfileCheck):
 
     def __init__(self, name, message, description, reference_url, tags, label, required, value_regex=None):
-        super(self.__class__, self) \
+        super(DockerfileLabelCheck, self) \
             .__init__(name, message, description, reference_url, tags)
         self.label = label
         self.required = required

--- a/colin/checks/abstract/envs.py
+++ b/colin/checks/abstract/envs.py
@@ -24,7 +24,7 @@ from .images import ImageCheck
 class EnvCheck(ContainerCheck, ImageCheck):
 
     def __init__(self, name, message, description, reference_url, tags, env_var, required, value_regex=None):
-        super(self.__class__, self) \
+        super(EnvCheck, self) \
             .__init__(name, message, description, reference_url, tags)
         self.env_var = env_var
         self.required = required

--- a/colin/checks/best_practices/cmd_or_entrypoint.py
+++ b/colin/checks/best_practices/cmd_or_entrypoint.py
@@ -13,9 +13,10 @@ class CmdOrEntrypointCheck(ContainerCheck, ImageCheck):
         super(self.__class__, self) \
             .__init__(name="cmd_or_entrypoint",
                       message="Cmd or Entrypoint has to be specified",
-                      description="",
-                      reference_url="?????",
-                      tags=["cmd", "entrypoint", "required"])
+                      description="An ENTRYPOINT allows you to configure a container that will run as an executable. "
+                                  "The main purpose of a CMD is to provide defaults for an executing container.",
+                      reference_url="https://fedoraproject.org/wiki/Container:Guidelines#CMD.2FENTRYPOINT_2",
+                      tags=["cmd", "entrypoint"])
 
     def check(self, target):
         metadata = target.instance.get_metadata()["Config"]

--- a/colin/checks/best_practices/cmd_or_entrypoint.py
+++ b/colin/checks/best_practices/cmd_or_entrypoint.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 class CmdOrEntrypointCheck(ContainerCheck, ImageCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(CmdOrEntrypointCheck, self) \
             .__init__(name="cmd_or_entrypoint",
                       message="Cmd or Entrypoint has to be specified",
                       description="An ENTRYPOINT allows you to configure a container that will run as an executable. "

--- a/colin/checks/best_practices/help_file.py
+++ b/colin/checks/best_practices/help_file.py
@@ -4,7 +4,7 @@ from colin.checks.abstract.filesystem import FileSystemCheck
 class HelpFileCheck(FileSystemCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(HelpFileCheck, self) \
             .__init__(name="help_file_required",
                       message="The 'helpfile' has to be provided.",
                       description="Just like traditional packages, containers need "

--- a/colin/checks/best_practices/help_file_or_readme.py
+++ b/colin/checks/best_practices/help_file_or_readme.py
@@ -4,7 +4,7 @@ from colin.checks.abstract.filesystem import FileSystemCheck
 class HelpFileOrReadmeCheck(FileSystemCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(HelpFileOrReadmeCheck, self) \
             .__init__(name="help_file_or_readme_required",
                       message="The 'helpfile' has to be provided.",
                       description="Just like traditional packages, containers need "

--- a/colin/checks/best_practices/no_root.py
+++ b/colin/checks/best_practices/no_root.py
@@ -6,10 +6,10 @@ from colin.checks.result import CheckResult
 class NoRootCheck(ContainerCheck, ImageCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(NoRootCheck, self) \
             .__init__(name="no_root",
                       message="Service should not run as root by default.",
-                      description="",
+                      description="It can be insecure to run service as root.",
                       reference_url="?????",
                       tags=["root", "user"])
 

--- a/colin/checks/dockerfile/from_tag.py
+++ b/colin/checks/dockerfile/from_tag.py
@@ -6,7 +6,7 @@ from colin.core.target import ImageName
 class FromTagCheck(DockerfileCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(FromTagCheck, self) \
             .__init__(name="from_tag_not_latest",
                       message="In FROM, tag has to be specified and not 'latest'.",
                       description="Using the 'latest' tag may cause unpredictable builds."

--- a/colin/checks/dockerfile/maintainer_deprecated.py
+++ b/colin/checks/dockerfile/maintainer_deprecated.py
@@ -4,7 +4,7 @@ from colin.checks.abstract.dockerfile import InstructionCountCheck
 class MaintainerDeprecatedCheck(InstructionCountCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(MaintainerDeprecatedCheck, self) \
             .__init__(name="maintainer_deprecated",
                       message="",
                       description="",

--- a/colin/checks/labels/architecture.py
+++ b/colin/checks/labels/architecture.py
@@ -4,14 +4,14 @@ from colin.checks.abstract.labels import LabelCheck
 class ArchitectureLabelCheck(LabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(ArchitectureLabelCheck, self) \
             .__init__(name="architecture_label",
                       message="Label 'architecture' has to be specified.",
                       description="Architecture the software in the image should target. "
                                   "(Optional: if omitted, it will be built "
                                   "for all supported Fedora Architectures)",
                       reference_url="https://fedoraproject.org/wiki/Container:Guidelines#LABELS",
-                      tags=["architecture", "label", "required", "optional"],
+                      tags=["architecture", "label"],
                       label="architecture",
                       required=True,
                       value_regex=None)

--- a/colin/checks/labels/architecture_capital_deprecated.py
+++ b/colin/checks/labels/architecture_capital_deprecated.py
@@ -4,7 +4,7 @@ from colin.checks.abstract.labels import DeprecatedLabelCheck
 class ArchitectureLabelCapitalDeprecatedCheck(DeprecatedLabelCheck):
 
     def __init__(self):
-        super(self.__class__, self). \
+        super(ArchitectureLabelCapitalDeprecatedCheck, self). \
             __init__(name="architecture_label_capital_deprecated",
                      message="Label 'Architecture' is deprecated.",
                      description="Replace with 'architecture'.",

--- a/colin/checks/labels/authoritative_source_url.py
+++ b/colin/checks/labels/authoritative_source_url.py
@@ -4,12 +4,12 @@ from colin.checks.abstract.labels import LabelCheck
 class AuthoritativeSourceUrlLabelCheck(LabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
-            .__init__(name="authoritative-source-url_label",
+        super(AuthoritativeSourceUrlLabelCheck, self) \
+            .__init__(name="authoritative_source-url_label",
                       message="Label 'authoritative-source-url' has to be specified.",
                       description="The authoritative registry in which the image is published.",
                       reference_url="https://fedoraproject.org/wiki/Container:Guidelines#LABELS",
-                      tags=["authoritative-source-url", "label", "required"],
+                      tags=["authoritative-source-url", "label"],
                       label="authoritative-source-url",
                       required=True,
                       value_regex=None)

--- a/colin/checks/labels/build_date.py
+++ b/colin/checks/labels/build_date.py
@@ -4,12 +4,12 @@ from colin.checks.abstract.labels import LabelCheck
 class BuildDateLabelCheck(LabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(BuildDateLabelCheck, self) \
             .__init__(name="build-date_label",
                       message="Label 'build-date' has to be specified.",
                       description="Date/Time image was built as RFC 3339 date-time.",
                       reference_url="https://github.com/projectatomic/ContainerApplicationGenericLabels",
-                      tags=["build-date", "label", "required"],
+                      tags=["build-date", "label"],
                       label="build-date",
                       required=True,
                       value_regex=None)

--- a/colin/checks/labels/bzcomponent_deprecated.py
+++ b/colin/checks/labels/bzcomponent_deprecated.py
@@ -4,7 +4,7 @@ from colin.checks.abstract.labels import DeprecatedLabelCheck
 class BZComponentDeprecatedCheck(DeprecatedLabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(BZComponentDeprecatedCheck, self) \
             .__init__(name="bzcomponent_deprecated",
                       message="Label 'BZComponent' is deprecated.",
                       description="Replace with 'com.redhat.component'.",

--- a/colin/checks/labels/com_redhat_build_host.py
+++ b/colin/checks/labels/com_redhat_build_host.py
@@ -4,12 +4,12 @@ from colin.checks.abstract.labels import LabelCheck
 class BuildHostLabelCheck(LabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(BuildHostLabelCheck, self) \
             .__init__(name="com.redhat.build-host_label",
                       message="Label 'com.redhat.build-host' has to be specified.",
                       description="The build host used to create an image for internal use and auditability, similar to the use in RPM.",
                       reference_url="https://fedoraproject.org/wiki/Container:Guidelines#LABELS",
-                      tags=["com.redhat.build-host", "build-host", "label", "required"],
+                      tags=["com.redhat.build-host", "build-host", "label"],
                       label="com.redhat.build-host",
                       required=True,
                       value_regex=None)

--- a/colin/checks/labels/com_redhat_component.py
+++ b/colin/checks/labels/com_redhat_component.py
@@ -4,12 +4,12 @@ from colin.checks.abstract.labels import LabelCheck
 class ComRedhatComponentCheck(LabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(ComRedhatComponentCheck, self) \
             .__init__(name="com_redhat_component_label_required",
                       message="Label 'com.redhat.component' has to be specified.",
                       description="The Bugzilla component name where bugs against this container should be reported by users.",
                       reference_url="https://fedoraproject.org/wiki/Container:Guidelines#LABELS",
-                      tags=["com.redhat.component", "label", "required"],
+                      tags=["com.redhat.component", "label"],
                       label="com.redhat.component",
                       required=True,
                       value_regex=None)

--- a/colin/checks/labels/description.py
+++ b/colin/checks/labels/description.py
@@ -4,12 +4,12 @@ from colin.checks.abstract.labels import LabelCheck
 class DescriptionLabelCheck(LabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(DescriptionLabelCheck, self) \
             .__init__(name="description_label",
                       message="Label 'description' has to be specified.",
                       description="Detailed description of the image.",
                       reference_url="https://github.com/projectatomic/ContainerApplicationGenericLabels",
-                      tags=["description", "label", "required"],
+                      tags=["description", "label"],
                       label="description",
                       required=True,
                       value_regex=None)

--- a/colin/checks/labels/distribution_scope.py
+++ b/colin/checks/labels/distribution_scope.py
@@ -4,12 +4,12 @@ from colin.checks.abstract.labels import LabelCheck
 class DescriptionScopeLabelCheck(LabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(DescriptionScopeLabelCheck, self) \
             .__init__(name="distribution-scope_label",
                       message="Label 'distribution-scope' has to be specified.",
                       description="Scope of intended distribution of the image. (private/authoritative-source-only/restricted/public)",
                       reference_url="https://github.com/projectatomic/ContainerApplicationGenericLabels",
-                      tags=["distribution-scope", "label", "required"],
+                      tags=["distribution-scope", "label"],
                       label="distribution-scope",
                       required=True,
                       value_regex=None)

--- a/colin/checks/labels/help.py
+++ b/colin/checks/labels/help.py
@@ -4,12 +4,12 @@ from colin.checks.abstract.labels import LabelCheck
 class HelpLabelCheck(LabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(HelpLabelCheck, self) \
             .__init__(name="help_label",
                       message="Label 'help' has to be specified.",
                       description="A runnable command which results in display of Help information.",
                       reference_url="https://fedoraproject.org/wiki/Container:Guidelines#LABELS",
-                      tags=["help", "label", "required", "optional"],
+                      tags=["help", "label"],
                       label="help",
                       required=True,
                       value_regex=None)

--- a/colin/checks/labels/install_capital_deprecated.py
+++ b/colin/checks/labels/install_capital_deprecated.py
@@ -4,7 +4,7 @@ from colin.checks.abstract.labels import DeprecatedLabelCheck
 class InstallLabelCapitalDeprecatedCheck(DeprecatedLabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(InstallLabelCapitalDeprecatedCheck, self) \
             .__init__(name="install_label_capital_deprecated",
                       message="Label 'INSTALL' is deprecated.",
                       description="Replace with 'install'.",

--- a/colin/checks/labels/io_k8s_description.py
+++ b/colin/checks/labels/io_k8s_description.py
@@ -1,15 +1,16 @@
 from colin.checks.abstract.labels import LabelCheck
 
 
-class DescriptionLabelCheck(LabelCheck):
+class IoK8sDescriptionLabelCheck(LabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(IoK8sDescriptionLabelCheck, self) \
             .__init__(name="io.k8s.description_label",
                       message="Label 'io.k8s.description' has to be specified.",
                       description="Description of the container displayed in Kubernetes",
-                      reference_url="https://github.com/projectatomic/ContainerApplicationGenericLabels/blob/master/vendor/redhat/labels.md",
-                      tags=["io.k8s.description", "description", "label", "required"],
+                      reference_url=["https://github.com/projectatomic/ContainerApplicationGenericLabels",
+                                     "https://github.com/projectatomic/ContainerApplicationGenericLabels/blob/master/vendor/redhat/labels.md#other-labels"],
+                      tags=["io.k8s.description", "description", "label"],
                       label="io.k8s.description",
                       required=True,
                       value_regex=None)

--- a/colin/checks/labels/io_k8s_display_name.py
+++ b/colin/checks/labels/io_k8s_display_name.py
@@ -1,15 +1,15 @@
 from colin.checks.abstract.labels import LabelCheck
 
 
-class IoOpenShiftTagsCheck(LabelCheck):
+class IoK8sDisplayNameCheck(LabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(IoK8sDisplayNameCheck, self) \
             .__init__(name="io_k8s_display-name_label_required",
                       message="Label 'io.k8s.display-name' has to be specified.",
                       description="This label is used to display a human readable name of an image inside the Image / Repo Overview page.",
                       reference_url="https://fedoraproject.org/wiki/Container:Guidelines#LABELS",
-                      tags=["io.k8s.display-name", "label", "required"],
+                      tags=["io.k8s.display-name", "label"],
                       label="io.k8s.display-name",
                       required=True,
                       value_regex=None)

--- a/colin/checks/labels/io_openshift_expose_services.py
+++ b/colin/checks/labels/io_openshift_expose_services.py
@@ -4,12 +4,13 @@ from colin.checks.abstract.labels import LabelCheck
 class IoOpenshiftExposeServicesLabelCheck(LabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(IoOpenshiftExposeServicesLabelCheck, self) \
             .__init__(name="io.openshift.expose-services_label",
                       message="Label 'io.openshift.expose-services' has to be specified.",
                       description="port:service pairs separated with comma, e.g. \"8080:http,8443:https\"",
-                      reference_url="?????",
-                      tags=["io.openshift.expose-services", "label", "optional"],
+                      reference_url=["https://github.com/projectatomic/ContainerApplicationGenericLabels",
+                                     "https://github.com/projectatomic/ContainerApplicationGenericLabels/blob/master/vendor/redhat/labels.md#other-labels"],
+                      tags=["io.openshift.expose-services", "label"],
                       label="io.openshift.expose-services",
                       required=True,
                       value_regex=None)

--- a/colin/checks/labels/io_openshift_tags.py
+++ b/colin/checks/labels/io_openshift_tags.py
@@ -4,12 +4,12 @@ from colin.checks.abstract.labels import LabelCheck
 class IoOpenShiftTagsCheck(LabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(IoOpenShiftTagsCheck, self) \
             .__init__(name="io_openshift_tags_label_required",
                       message="Label 'io.openshift.tags' has to be specified.",
                       description="The primary purpose of this label is to include all relevant search terms for this image.",
                       reference_url="https://fedoraproject.org/wiki/Container:Guidelines#LABELS",
-                      tags=["io.openshift.tags", "label", "required"],
+                      tags=["io.openshift.tags", "label"],
                       label="io.openshift.tags",
                       required=True,
                       value_regex=None)

--- a/colin/checks/labels/maintainer.py
+++ b/colin/checks/labels/maintainer.py
@@ -1,10 +1,10 @@
 from colin.checks.abstract.labels import LabelCheck
 
 
-class MaintainerCheck(LabelCheck):
+class MaintainerLabelCheck(LabelCheck):
 
     def __init__(self):
-        super(MaintainerCheck, self) \
+        super(MaintainerLabelCheck, self) \
             .__init__(name="maintainer_label_required",
                       message="Label 'maintainer' has to be specified.",
                       description="The name and email of the maintainer (usually the submitter).",

--- a/colin/checks/labels/maintainer.py
+++ b/colin/checks/labels/maintainer.py
@@ -4,12 +4,12 @@ from colin.checks.abstract.labels import LabelCheck
 class MaintainerCheck(LabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(MaintainerCheck, self) \
             .__init__(name="maintainer_label_required",
                       message="Label 'maintainer' has to be specified.",
                       description="The name and email of the maintainer (usually the submitter).",
                       reference_url="https://fedoraproject.org/wiki/Container:Guidelines#LABELS",
-                      tags=["maintainer", "label", "required"],
+                      tags=["maintainer", "label"],
                       label="maintainer",
                       required=True,
                       value_regex=None)

--- a/colin/checks/labels/name.py
+++ b/colin/checks/labels/name.py
@@ -4,12 +4,12 @@ from colin.checks.abstract.labels import LabelCheck
 class NameCheck(LabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(NameCheck, self) \
             .__init__(name="name_label_required",
                       message="Label 'name' has to be specified.",
                       description="Name of the Image or Container.",
                       reference_url="https://fedoraproject.org/wiki/Container:Guidelines#LABELS",
-                      tags=["name", "label", "required"],
+                      tags=["name", "label"],
                       label="name",
                       required=True,
                       value_regex=None)

--- a/colin/checks/labels/name_capital_deprecated.py
+++ b/colin/checks/labels/name_capital_deprecated.py
@@ -4,7 +4,7 @@ from colin.checks.abstract.labels import DeprecatedLabelCheck
 class NameLabelCapitalDeprecatedCheck(DeprecatedLabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(NameLabelCapitalDeprecatedCheck, self) \
             .__init__(name="name_label_capital_deprecated",
                       message="Label 'Name' is deprecated.",
                       description="Replace with 'name'.",

--- a/colin/checks/labels/release.py
+++ b/colin/checks/labels/release.py
@@ -4,12 +4,12 @@ from colin.checks.abstract.labels import LabelCheck
 class ReleaseLabelCheck(LabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(ReleaseLabelCheck, self) \
             .__init__(name="release_label",
                       message="Label 'release' has to be specified.",
                       description="Release Number for this version.",
                       reference_url="https://fedoraproject.org/wiki/Container:Guidelines#LABELS",
-                      tags=["release", "label", "required"],
+                      tags=["release", "label"],
                       label="release",
                       required=True,
                       value_regex=None)

--- a/colin/checks/labels/release_capital_deprecated.py
+++ b/colin/checks/labels/release_capital_deprecated.py
@@ -4,7 +4,7 @@ from colin.checks.abstract.labels import DeprecatedLabelCheck
 class ReleaseLabelCapitalDeprecatedCheck(DeprecatedLabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(ReleaseLabelCapitalDeprecatedCheck, self) \
             .__init__(name="release_label_capital_deprecated",
                       message="Label 'Release' is deprecated.",
                       description="Replace with 'release'.",

--- a/colin/checks/labels/summary.py
+++ b/colin/checks/labels/summary.py
@@ -4,12 +4,12 @@ from colin.checks.abstract.labels import LabelCheck
 class SummaryCheck(LabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(SummaryCheck, self) \
             .__init__(name="summary_label_required",
                       message="Label 'summary' has to be specified.",
                       description="A short description of the image.",
                       reference_url="https://fedoraproject.org/wiki/Container:Guidelines#LABELS",
-                      tags=["summary", "label", "required"],
+                      tags=["summary", "label"],
                       label="summary",
                       required=True,
                       value_regex=None)

--- a/colin/checks/labels/uninstall_capital_deprecated.py
+++ b/colin/checks/labels/uninstall_capital_deprecated.py
@@ -4,7 +4,7 @@ from colin.checks.abstract.labels import DeprecatedLabelCheck
 class UninstallLabelCapitalDeprecatedCheck(DeprecatedLabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(UninstallLabelCapitalDeprecatedCheck, self) \
             .__init__(name="uninstall_label_capital_deprecated",
                       message="Label 'UNINSTALL' is deprecated.",
                       description="Replace with 'uninstall'.",

--- a/colin/checks/labels/url.py
+++ b/colin/checks/labels/url.py
@@ -4,13 +4,12 @@ from colin.checks.abstract.labels import LabelCheck
 class UrlLabelCheck(LabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(UrlLabelCheck, self) \
             .__init__(name="url_label",
                       message="Label 'url' has to be specified.",
                       description="A URL where the user can find more information about the image.",
                       reference_url="https://fedoraproject.org/wiki/Container:Guidelines#LABELS",
-                      tags=["url", "label", "required"],
+                      tags=["url", "label"],
                       label="url",
                       required=True,
                       value_regex=None)
-        # TODO: Check the format for RHEL

--- a/colin/checks/labels/usage.py
+++ b/colin/checks/labels/usage.py
@@ -1,15 +1,15 @@
 from colin.checks.abstract.labels import LabelCheck
 
 
-class UsageCheck(LabelCheck):
+class UsageLabelCheck(LabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(UsageLabelCheck, self) \
             .__init__(name="usage_label_required",
                       message="Label 'usage' has to be specified.",
                       description="A human readable example of container execution.",
                       reference_url="https://fedoraproject.org/wiki/Container:Guidelines#LABELS",
-                      tags=["usage", "label", "required"],
+                      tags=["usage", "label"],
                       label="usage",
                       required=True,
                       value_regex=None)

--- a/colin/checks/labels/vcs_ref.py
+++ b/colin/checks/labels/vcs_ref.py
@@ -4,12 +4,12 @@ from colin.checks.abstract.labels import LabelCheck
 class VcsRefLabelCheck(LabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(VcsRefLabelCheck, self) \
             .__init__(name="vcs-ref_label",
                       message="Label 'vcs-ref' has to be specified.",
                       description="A 'reference' within the version control repository; e.g. a git commit, or a subversion branch.",
                       reference_url="https://github.com/projectatomic/ContainerApplicationGenericLabels",
-                      tags=["vcs-ref", "vcs", "label", "required"],
+                      tags=["vcs-ref", "vcs", "label"],
                       label="vcs-ref",
                       required=True,
                       value_regex=None)

--- a/colin/checks/labels/vcs_type.py
+++ b/colin/checks/labels/vcs_type.py
@@ -4,13 +4,13 @@ from colin.checks.abstract.labels import LabelCheck
 class VcsTypeLabelCheck(LabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(VcsTypeLabelCheck, self) \
             .__init__(name="vcs-type_label",
                       message="Label 'vcs-type' has to be specified.",
                       description="The type of version control used by the container source."
                                   "Generally one of git, hg, svn, bzr, cvs",
                       reference_url="https://github.com/projectatomic/ContainerApplicationGenericLabels",
-                      tags=["vcs-type", "vcs", "label", "required"],
+                      tags=["vcs-type", "vcs", "label"],
                       label="vcs-type",
                       required=True,
                       value_regex=None)

--- a/colin/checks/labels/vcs_url.py
+++ b/colin/checks/labels/vcs_url.py
@@ -4,12 +4,12 @@ from colin.checks.abstract.labels import LabelCheck
 class VcsUrlLabelCheck(LabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(VcsUrlLabelCheck, self) \
             .__init__(name="vcs-url_label",
                       message="Label 'vcs-url' has to be specified.",
                       description="URL of the version control repository.",
                       reference_url="https://github.com/projectatomic/ContainerApplicationGenericLabels",
-                      tags=["vcs-url", "vcs", "label", "optional"],
+                      tags=["vcs-url", "vcs", "label"],
                       label="vcs-url",
                       required=True,
                       value_regex=None)

--- a/colin/checks/labels/vendor.py
+++ b/colin/checks/labels/vendor.py
@@ -7,9 +7,8 @@ class VendorLabelCheck(LabelCheck):
         super(VendorLabelCheck, self) \
             .__init__(name="vendor_label",
                       message="Label 'vendor' has to be specified.",
-                      description="'Red Hat, Inc.'",
+                      description="Name of the vendor.",
                       reference_url="https://github.com/projectatomic/ContainerApplicationGenericLabels/blob/master/vendor/redhat/labels.md",
                       tags=["vendor", "label"],
                       label="vendor",
-                      required=True,
-                      value_regex="^Red Hat, Inc.$")
+                      required=True)

--- a/colin/checks/labels/vendor.py
+++ b/colin/checks/labels/vendor.py
@@ -4,12 +4,12 @@ from colin.checks.abstract.labels import LabelCheck
 class VendorLabelCheck(LabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(VendorLabelCheck, self) \
             .__init__(name="vendor_label",
                       message="Label 'vendor' has to be specified.",
                       description="'Red Hat, Inc.'",
                       reference_url="https://github.com/projectatomic/ContainerApplicationGenericLabels/blob/master/vendor/redhat/labels.md",
-                      tags=["vendor", "label", "required"],
+                      tags=["vendor", "label"],
                       label="vendor",
                       required=True,
                       value_regex="^Red Hat, Inc.$")

--- a/colin/checks/labels/version.py
+++ b/colin/checks/labels/version.py
@@ -4,12 +4,12 @@ from colin.checks.abstract.labels import LabelCheck
 class VersionCheck(LabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(VersionCheck, self) \
             .__init__(name="version_label_required",
                       message="Label 'version' has to be specified.",
                       description="Version of the image.",
                       reference_url="https://fedoraproject.org/wiki/Container:Guidelines#LABELS",
-                      tags=["version", "label", "required"],
+                      tags=["version", "label"],
                       label="version",
                       required=True,
                       value_regex=None)

--- a/colin/checks/labels/version_capital_deprecated.py
+++ b/colin/checks/labels/version_capital_deprecated.py
@@ -4,7 +4,7 @@ from colin.checks.abstract.labels import DeprecatedLabelCheck
 class VersionLabelCapitalDeprecatedCheck(DeprecatedLabelCheck):
 
     def __init__(self):
-        super(self.__class__, self) \
+        super(VersionLabelCapitalDeprecatedCheck, self) \
             .__init__(name="version_label_capital_deprecated",
                       message="Label 'Version' is deprecated.",
                       description="Replace with 'version'.",

--- a/rulesets/fedora.json
+++ b/rulesets/fedora.json
@@ -13,15 +13,15 @@
     "optional": [
       "url",
       "help",
-      "build-date",
-      "distribution-scope",
-      "vcs-ref",
-      "vcs-type",
+      "build_date",
+      "distribution_scope",
+      "vcs_ref",
+      "vcs_type",
       "description",
       "io_k8s_description",
-      "vcs-url",
+      "vcs_url",
       "maintainer",
-      "io_openshift_expose-services"
+      "io_openshift_expose_services"
     ]
   },
   "dockerfile": {


### PR DESCRIPTION
- Correct maintainer and vendor checks.
- Correct super calls.
- Change - to _ in check filenames.
- Add reference urls.