### PR TITLE
Naming of abstract classes and another small changes after big change

### DIFF
--- a/colin/checks/dockerfile.py
+++ b/colin/checks/dockerfile.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from colin.core.checks.dockerfile import DockerfileAbstractCheck, InstructionCountCheck
+from colin.core.checks.dockerfile import DockerfileAbstractCheck, InstructionCountAbstractCheck
 from colin.core.result import CheckResult
 from colin.core.target import ImageName
 
@@ -41,7 +41,7 @@ class FromTagNotLatestCheck(DockerfileAbstractCheck):
                            logs=[])
 
 
-class MaintainerDeprecatedCheck(InstructionCountCheck):
+class MaintainerDeprecatedCheck(InstructionCountAbstractCheck):
 
     def __init__(self):
         super(MaintainerDeprecatedCheck, self) \

--- a/colin/checks/dynamic.py
+++ b/colin/checks/dynamic.py
@@ -14,10 +14,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from colin.core.checks.cmd import CmdCheck
+from colin.core.checks.cmd import CmdAbstractCheck
 
 
-class ShellRunableCheck(CmdCheck):
+class ShellRunableCheck(CmdAbstractCheck):
 
     def __init__(self):
         super(ShellRunableCheck, self) \

--- a/colin/core/checks/abstract_check.py
+++ b/colin/core/checks/abstract_check.py
@@ -36,13 +36,11 @@ class AbstractCheck(object):
                "   -> {}\n" \
                "   -> {}\n" \
                "   -> {}\n" \
-               "   -> {}\n" \
-               "   -> Required: {}\n".format(self.name,
-                                             self.message,
-                                             self.description,
-                                             self.reference_url,
-                                             ", ".join(self.tags),
-                                             self.severity)
+               "   -> {}\n".format(self.name,
+                                   self.message,
+                                   self.description,
+                                   self.reference_url,
+                                   ", ".join(self.tags))
 
     @property
     def json(self):

--- a/colin/core/checks/cmd.py
+++ b/colin/core/checks/cmd.py
@@ -23,12 +23,12 @@ from .containers import ContainerAbstractCheck
 from .images import ImageAbstractCheck
 
 
-class CmdCheck(ContainerAbstractCheck, ImageAbstractCheck):
+class CmdAbstractCheck(ContainerAbstractCheck, ImageAbstractCheck):
 
     def __init__(self, name, message, description, reference_url, tags, cmd, expected_output=None,
                  expected_regex=None,
                  substring=None):
-        super(CmdCheck, self).__init__(name, message, description, reference_url, tags)
+        super(CmdAbstractCheck, self).__init__(name, message, description, reference_url, tags)
         self.cmd = cmd
         self.expected_output = expected_output
         self.expected_regex = expected_regex

--- a/colin/core/checks/dockerfile.py
+++ b/colin/core/checks/dockerfile.py
@@ -39,10 +39,10 @@ class DockerfileAbstractCheck(AbstractCheck):
     pass
 
 
-class InstructionCheck(DockerfileAbstractCheck):
+class InstructionAbstractCheck(DockerfileAbstractCheck):
 
     def __init__(self, name, message, description, reference_url, tags, instruction, value_regex, required):
-        super(InstructionCheck, self) \
+        super(InstructionAbstractCheck, self) \
             .__init__(name, message, description, reference_url, tags)
         self.instruction = instruction
         self.value_regex = value_regex
@@ -70,10 +70,10 @@ class InstructionCheck(DockerfileAbstractCheck):
                            logs=logs)
 
 
-class InstructionCountCheck(DockerfileAbstractCheck):
+class InstructionCountAbstractCheck(DockerfileAbstractCheck):
 
     def __init__(self, name, message, description, reference_url, tags, instruction, min_count=None, max_count=None):
-        super(InstructionCountCheck, self) \
+        super(InstructionCountAbstractCheck, self) \
             .__init__(name, message, description, reference_url, tags)
         self.instruction = instruction
         self.min_count = min_count
@@ -101,10 +101,10 @@ class InstructionCountCheck(DockerfileAbstractCheck):
                            logs=[log])
 
 
-class DockerfileLabelCheck(DockerfileAbstractCheck):
+class DockerfileLabelAbstractCheck(DockerfileAbstractCheck):
 
     def __init__(self, name, message, description, reference_url, tags, label, required, value_regex=None):
-        super(DockerfileLabelCheck, self) \
+        super(DockerfileLabelAbstractCheck, self) \
             .__init__(name, message, description, reference_url, tags)
         self.label = label
         self.required = required

--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -14,12 +14,18 @@
       "name": "from_tag_not_latest",
       "additional_tags": [
         "required"
+      ],
+      "usable_targets": [
+        "dockerfile"
       ]
     },
     {
       "name": "maintainer_deprecated",
       "additional_tags": [
         "required"
+      ],
+      "usable_targets": [
+        "dockerfile"
       ]
     }
   ]


### PR DESCRIPTION
- Correct default ruleset file.
- Remove severity from the check str representation.
- Use AbstractCheck ending for all abstract checks.