### PR TITLE
release-bot config file

### DIFF
--- a/release-conf.yaml
+++ b/release-conf.yaml
@@ -1,0 +1,10 @@
+# list of major python versions that release-bot will build separate wheels for
+python_versions:
+  - 3
+  - 2
+# whether to release on fedora
+fedora: true
+# list of fedora branches bot should release on. Master is always implied
+fedora_branches:
+  - f28
+  - f27


### PR DESCRIPTION
I don't see any wheels in https://pypi.org/project/colin/#files but `python3 setup.py bdist_wheel` and `python2 setup.py bdist_wheel` seem to make correct wheels so I hope you don't mind building/uploading wheels for python 2 and 3.