### PR TITLE
do not mount whole FS when checking for files

### DIFF
--- a/colin/checks/best_practices.py
+++ b/colin/checks/best_practices.py
@@ -17,7 +17,7 @@
 import logging
 
 from colin.core.checks.containers import ContainerAbstractCheck
-from colin.core.checks.filesystem import FileSystemCheck
+from colin.core.checks.filesystem import FileCheck
 from colin.core.checks.images import ImageAbstractCheck
 from colin.core.result import CheckResult
 from colin.core.target import inspect_object
@@ -59,7 +59,7 @@ class CmdOrEntrypointCheck(ContainerAbstractCheck, ImageAbstractCheck):
                            logs=[msg_cmd_present, msg_entrypoint_present])
 
 
-class HelpFileOrReadmeCheck(FileSystemCheck):
+class HelpFileOrReadmeCheck(FileCheck):
     name = "help_file_or_readme"
 
     def __init__(self):

--- a/colin/core/check_runner.py
+++ b/colin/core/check_runner.py
@@ -37,5 +37,5 @@ def _result_generator(target, checks):
         except Exception as ex:
             tb = traceback.format_exc()
             logger.warning(
-                "There occurred an error when executing the check: {}".format(tb))
+                "There was an error while performing check: {}".format(tb))
             yield FailedCheckResult(check, logs=[str(ex)])

--- a/colin/core/checks/filesystem.py
+++ b/colin/core/checks/filesystem.py
@@ -120,5 +120,5 @@ class FileSystemCheck(ContainerAbstractCheck, ImageAbstractCheck):
                                    check_name=self.name,
                                    logs=logs)
         except Exception as ex:
-            raise ColinException("Problem with mounting filesystem with atomic. ({})"
-                                 .format(str(ex)))
+            raise ColinException("There was an error while operating on filesystem of {}: {}"
+                                 .format(target.instance, str(ex)))

--- a/colin/core/checks/filesystem.py
+++ b/colin/core/checks/filesystem.py
@@ -13,11 +13,76 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+import logging
 
+from conu import DockerRunBuilder
+from conu.exceptions import ConuException
+
+from colin.core.target import TargetType
 from ..exceptions import ColinException
 from ..result import CheckResult
 from .containers import ContainerAbstractCheck
 from .images import ImageAbstractCheck
+
+
+logger = logging.getLogger(__name__)
+
+
+class FileCheck(ContainerAbstractCheck, ImageAbstractCheck):
+    """ Check presence of files; w/o mounting the whole FS """
+
+    def __init__(self, message, description, reference_url, tags, files, all_must_be_present):
+        super(FileCheck, self) \
+            .__init__(message, description, reference_url, tags)
+        self.files = files
+        self.all_must_be_present = all_must_be_present
+
+    def check(self, target):
+        passed = self.all_must_be_present
+        cleanup = False
+
+        if target.target_type is TargetType.IMAGE:
+            drb = DockerRunBuilder(command=["/bin/sleep", "infinity"],
+                                   additional_opts=["--entrypoint="])
+            cont = target.instance.run_via_binary(run_command_instance=drb)
+            cleanup = True
+        elif target.target_type is TargetType.CONTAINER:
+            cont = target.instance
+        else:
+            return CheckResult(ok=False,
+                               description=self.description,
+                               message=self.message,
+                               reference_url=self.reference_url,
+                               check_name=self.name,
+                               logs=["Unsupported target, this check can "
+                                     "process only containers and images"])
+        logs = []
+        try:
+            for f in self.files:
+                cmd = ["/bin/ls", "-1", f]
+                try:
+                    f_present = cont.execute(cmd)
+                    logs.append("File '{}' is {}present."
+                                .format(f, "" if f_present else "not "))
+                except ConuException as ex:
+                    logger.info("File %s is not present, ex: %s", f, ex)
+                    f_present = False
+                    logs.append("File {} is not present.".format(f))
+                if self.all_must_be_present:
+                    passed = f_present and passed
+                else:
+                    passed = f_present or passed
+
+            return CheckResult(ok=passed,
+                               description=self.description,
+                               message=self.message,
+                               reference_url=self.reference_url,
+                               check_name=self.name,
+                               logs=logs)
+        finally:
+            if cleanup:
+                cont.stop()
+                cont.delete()
 
 
 class FileSystemCheck(ContainerAbstractCheck, ImageAbstractCheck):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ IMAGES = {
 
 
 def build_images():
+    """ build container images we need for testing """
     this_dir = os.path.abspath(os.path.dirname(__file__))
     data_dir = os.path.join(this_dir, "data")
     with DockerBackend() as backend:
@@ -34,9 +35,11 @@ def build_images():
 
 @pytest.fixture(autouse=True, scope='session')
 def setup_test_session():
-    for x in IMAGES.keys():
+    """ set up environment before testing """
+    for image_name in IMAGES:
         try:
-            subprocess.check_call(["docker", "image", "inspect", x], stdout=subprocess.PIPE)
+            subprocess.check_call(["docker", "image", "inspect", image_name],
+                                  stdout=subprocess.PIPE)
         except subprocess.CalledProcessError:
             break
     # executed if break was not reached

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,47 @@
 import logging
+import os
+import subprocess
+
+import pytest
+from conu import DockerBackend
 
 from colin.core.colin import _set_logging
 
+
 _set_logging(level=logging.DEBUG)
+
+
+BASH_IMAGE = "colin-test-bash"
+LS_IMAGE = "colin-test-ls"
+IMAGES = {
+    BASH_IMAGE: {
+        "dockerfile_path": "Dockerfile-bash"
+    },
+    LS_IMAGE: {
+        "dockerfile_path": "Dockerfile-ls"
+    }
+}
+
+
+def build_images():
+    this_dir = os.path.abspath(os.path.dirname(__file__))
+    data_dir = os.path.join(this_dir, "data")
+    with DockerBackend() as backend:
+        for image_name, image_data in IMAGES.items():
+            backend.ImageClass.build(data_dir, tag=image_name,
+                                     dockerfile=image_data["dockerfile_path"])
+
+
+@pytest.fixture(autouse=True, scope='session')
+def setup_test_session():
+    for x in IMAGES.keys():
+        try:
+            subprocess.check_call(["docker", "image", "inspect", x], stdout=subprocess.PIPE)
+        except subprocess.CalledProcessError:
+            break
+    # executed if break was not reached
+    else:
+        # all images were found, we're good
+        return
+    # the loop ended with break, create images
+    build_images()

--- a/tests/data/Dockerfile-bash
+++ b/tests/data/Dockerfile-bash
@@ -1,0 +1,2 @@
+FROM fedora:28
+COPY files/usage README.md

--- a/tests/data/Dockerfile-ls
+++ b/tests/data/Dockerfile-ls
@@ -1,3 +1,4 @@
 FROM fedora:28
+COPY files/usage usage
 ENTRYPOINT ["/bin/ls"]
 CMD ["/"]

--- a/tests/integration/dynamic_check_data/Dockerfile-bash
+++ b/tests/integration/dynamic_check_data/Dockerfile-bash
@@ -1,1 +1,0 @@
-FROM fedora:28

--- a/tests/integration/test_dynamic_checks.py
+++ b/tests/integration/test_dynamic_checks.py
@@ -13,11 +13,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-import os
-
 import colin
 import pytest
-from conu import DockerBackend
+
+from tests.conftest import LS_IMAGE, BASH_IMAGE
 
 
 @pytest.fixture()
@@ -36,21 +35,10 @@ def ruleset():
 
 
 def test_dynamic_check_ls(ruleset):
-    image = build_image(dockerfile="Dockerfile-ls")
-    results = colin.run(target=image, ruleset=ruleset, logging_level=10)
+    results = colin.run(target=LS_IMAGE, ruleset=ruleset, logging_level=10)
     assert not results.ok
 
 
 def test_dynamic_check_bash(ruleset):
-    image = build_image(dockerfile="Dockerfile-bash")
-    results = colin.run(target=image, ruleset=ruleset, logging_level=10)
+    results = colin.run(target=BASH_IMAGE, ruleset=ruleset, logging_level=10)
     assert results.ok
-
-
-def build_image(dockerfile):
-    with DockerBackend() as backend:
-        name = 'colin-test-dynamic-check-image'
-        integration_tests_dir = os.path.abspath(os.path.dirname(__file__))
-        image_dir = os.path.join(integration_tests_dir, "dynamic_check_data")
-
-        return backend.ImageClass.build(os.path.join(image_dir), tag=name, dockerfile=dockerfile)

--- a/tests/integration/test_fs_checks.py
+++ b/tests/integration/test_fs_checks.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+import colin
+import pytest
+
+from tests.conftest import BASH_IMAGE, LS_IMAGE
+
+
+@pytest.fixture()
+def ruleset():
+    return {
+        "version": "1",
+        "name": "Laughing out loud ruleset",
+        "description": "This set of checks is required to pass because we said it",
+        "contact_email": "forgot-to-reply@example.nope",
+        "checks": [
+            {
+                "name": "help_file_or_readme"
+            }
+        ]
+    }
+
+
+@pytest.mark.parametrize("image_name,should_pass", [
+    (LS_IMAGE, False),
+    (BASH_IMAGE, True),
+])
+def test_help_file_or_readme(ruleset, image_name, should_pass):
+    results = colin.run(target=image_name, ruleset=ruleset, logging_level=10)
+    assert results.ok
+    assert results.fail is not should_pass
+

--- a/tests/integration/test_fs_checks.py
+++ b/tests/integration/test_fs_checks.py
@@ -21,6 +21,7 @@ from tests.conftest import BASH_IMAGE, LS_IMAGE
 
 @pytest.fixture()
 def ruleset():
+    """ simple ruleset as a pytest fixture """
     return {
         "version": "1",
         "name": "Laughing out loud ruleset",
@@ -39,6 +40,7 @@ def ruleset():
     (BASH_IMAGE, True),
 ])
 def test_help_file_or_readme(ruleset, image_name, should_pass):
+    """ verify that help_file_or_readme check works well """
     results = colin.run(target=image_name, ruleset=ruleset, logging_level=10)
     assert results.ok
     assert results.fail is not should_pass


### PR DESCRIPTION
* this saves so much time; also requires ton of memory if the image is
  beefy

\+

* error messages: grammar
* move test images creation to conftest.py