### PR TITLE
Correct CLI test

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -41,8 +41,9 @@ def _common_help_options(result):
 def test_check_command():
     result = _call_colin(check)
     expected_output = """Usage: check [OPTIONS] TARGET
+Try "check -h" for help.
 
-Error: Missing argument "target".
+Error: Missing argument "TARGET".
 """
     assert result.exit_code == 2
     assert result.output == expected_output


### PR DESCRIPTION
Fix [errors in Centos CI](https://ci.centos.org/job/user-cont-colin-pr/51/console):

```
13:41:12 ______________________________ test_check_command ______________________________
13:41:12 
13:41:12     def test_check_command():
13:41:12         result = _call_colin(check)
13:41:12         expected_output = """Usage: check [OPTIONS] TARGET
13:41:12    
13:41:12     Error: Missing argument "target".
13:41:12     """ 
13:41:12         assert result.exit_code == 2
13:41:12 >       assert result.output == expected_output
13:41:12 E       assert 'Usage: check...t "TARGET".\n' == 'Usage: check ...t "target".\n'
13:41:12 E           Usage: check [OPTIONS] TARGET
13:41:12 E         - Try "check -h" for help.
13:41:12 E    
13:41:12 E         - Error: Missing argument "TARGET".
13:41:12 E         ?                          ^^^^^^
13:41:12 E         + Error: Missing argument "target".
13:41:12 E         ?                          ^^^^^^
13:41:12 
13:41:12 tests/unit/test_cli.py:50: AssertionError
```