### PR TITLE
more descriptive 0.3.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,20 @@
 
 ## New Features
 
-* Add check timeouts
-* Add support for check skip
+* You can configure timeout for checks now:
+  * This can be done via CLI or add `timeout: <seconds>` to a check in a ruleset.
+  * Default timeout is set to 10 minutes.
+* Checks can be skipped via CLI option `--skip`.
 
 ## Breaking changes
 
-* Use search method in label regex
+* Colin searches a value in label now instead of matching it using a regex.
 
 ## Fixes
 
-* Error result when the check code cannot be found
-* Error result when missing FROM in testing image tag
+* Output a sensible error message when the check code cannot be found.
+* Handle the situation when the instruction FROM is missing in testing image tag.
+
 
 # 0.2.1
 


### PR DESCRIPTION
@user-cont/the-team when you are writing changelogs for our open source projects, please think about these:

 * The changelog is meant to be read by everyone. Imagine that an average user
   will read it and should understand the changes. `Add check timeouts` is
   completely undescriptive.
 * Every line should be a complete sentence. Either tell what is the change that the tool is doing or describe it precisely:
   * Bad: `Use search method in label regex`
   * Good: `Colin now uses search method when...`
 * And finally, with the changelogs we are essentially selling our projects:
   think about a situation that you met someone at a conference and you are
   trying to convince the person to use the project and that the changelog
   should help with that.