### PR TITLE
Packaging and metadata fixes

### DIFF
--- a/colin.spec
+++ b/colin.spec
@@ -28,7 +28,6 @@ Summary:        %{summary}
 %{?python_provide:%python_provide python3-%{pypi_name}}
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
-Requires:       python3-conu
 Requires:       python3-click
 Requires:       python3-six
 Requires:       python3-dockerfile-parse

--- a/colin/checks/best_practices.py
+++ b/colin/checks/best_practices.py
@@ -28,8 +28,7 @@ class CmdOrEntrypointCheck(FMFAbstractCheck, ImageAbstractCheck):
     name = "cmd_or_entrypoint"
 
     def check(self, target):
-        raise RuntimeError("This check is not supported now: skopeo doesn't provide this metadata.")
-        metadata = target.config_metadata
+        metadata = target.config_metadata["ContainerConfig"]
         cmd_present = "Cmd" in metadata and metadata["Cmd"]
         msg_cmd_present = "Cmd {}specified.".format("" if cmd_present else "not ")
         logger.debug(msg_cmd_present)
@@ -56,7 +55,6 @@ class NoRootCheck(FMFAbstractCheck, ImageAbstractCheck):
     name = "no_root"
 
     def check(self, target):
-        raise RuntimeError("This check is not supported now: skopeo doesn't provide this metadata.")
         metadata = target.config_metadata
         root_present = "User" in metadata and metadata["User"] in ["", "0", "root"]
 

--- a/colin/cli/colin.py
+++ b/colin/cli/colin.py
@@ -19,11 +19,9 @@ import os
 import sys
 
 import click
-import conu
 import six
 
-from colin.utils.cmd_tools import get_version_msg_from_the_cmd, is_rpm_installed, \
-    get_version_of_the_python_package
+from colin.utils.cmd_tools import get_version_msg_from_the_cmd, is_rpm_installed
 from .default_group import DefaultGroup
 from ..core.checks.abstract_check import AbstractCheck
 from ..core.colin import get_checks, run
@@ -227,7 +225,7 @@ def info():
     click.echo("colin {} {}".format(__version__, installation_path))
     click.echo("colin-cli {}\n".format(os.path.realpath(__file__)))
 
-    click.echo(get_version_of_the_python_package(module=conu))
+    # click.echo(get_version_of_the_python_package(module=conu))
 
     rpm_installed = is_rpm_installed()
     click.echo(get_version_msg_from_the_cmd(package_name="podman", use_rpm=rpm_installed))

--- a/colin/core/checks/cmd.py
+++ b/colin/core/checks/cmd.py
@@ -15,8 +15,6 @@
 #
 import re
 
-from conu import ConuException
-
 from .abstract_check import ImageAbstractCheck
 from ..exceptions import ColinException
 from ..result import CheckResult, FailedCheckResult
@@ -37,18 +35,20 @@ class CmdAbstractCheck(ImageAbstractCheck):
 
         try:
             output = target.get_output(cmd=self.cmd)
-        except ConuException as ex:
-            if str(ex).endswith("exit code 126") or str(ex).endswith("error: 127"):
-                return CheckResult(ok=False,
-                                   description=self.description,
-                                   message=self.message,
-                                   reference_url=self.reference_url,
-                                   check_name=self.name,
-                                   logs=["exec: '{}': executable file not found in $PATH".format(
-                                       self.cmd)])
-            return FailedCheckResult(check=self,
-                                     logs=[str(ex)])
 
+            """
+            except ConuException as ex:
+                if str(ex).endswith("exit code 126") or str(ex).endswith("error: 127"):
+                    return CheckResult(ok=False,
+                                       description=self.description,
+                                       message=self.message,
+                                       reference_url=self.reference_url,
+                                       check_name=self.name,
+                                       logs=["exec: '{}': executable file not found in $PATH".format(
+                                           self.cmd)])
+                return FailedCheckResult(check=self,
+                                         logs=[str(ex)])
+            """
         except ColinException as ex:
             return FailedCheckResult(check=self,
                                      logs=[str(ex)])

--- a/colin/core/checks/filesystem.py
+++ b/colin/core/checks/filesystem.py
@@ -71,7 +71,7 @@ class FileCheck(ImageAbstractCheck):
                 f_present = cont.execute(cmd)
                 logs.append("File '{}' is {}present."
                             .format(f, "" if f_present else "not "))
-            except ConuException as ex:
+            except Exception as ex:
                 logger.info("File %s is not present, ex: %s", f, ex)
                 f_present = False
                 logs.append("File {} is not present.".format(f))

--- a/colin/core/checks/filesystem.py
+++ b/colin/core/checks/filesystem.py
@@ -15,8 +15,6 @@
 #
 import logging
 
-from conu.exceptions import ConuException
-
 from .abstract_check import ImageAbstractCheck
 from ..result import CheckResult
 

--- a/colin/core/colin.py
+++ b/colin/core/colin.py
@@ -43,7 +43,7 @@ def run(
     :param timeout: timeout per-check (in seconds)
     :param skips: name of checks to skip
     :param target: str (image name, ostree or dockertar)
-                    or Image (instance from conu)
+                    or ImageTarget
                     or path/file-like object for dockerfile
     :param target_type: string, either image, dockerfile, dockertar
     :param tags: list of str (if not None, the checks will be filtered by tags.)

--- a/docs/python_api.rst
+++ b/docs/python_api.rst
@@ -30,7 +30,7 @@ Functions
     :param timeout: timeout per-check (in seconds)
     :param skips: name of checks to skip
     :param target: str (image name, ostree or dockertar)
-                    or Image (instance from conu)
+                    or ImageTarget
                     or path/file-like object for dockerfile
     :param target_type: string, either image, dockerfile, dockertar
     :param tags: list of str (if not None, the checks will be filtered by tags.)

--- a/release-conf.yaml
+++ b/release-conf.yaml
@@ -1,7 +1,7 @@
 # list of major python versions that release-bot will build separate wheels for
 python_versions:
   - 3
-  - 2
+  
 # whether to release on fedora
 fedora: true
 # list of fedora branches bot should release on. Master is always implied

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
     install_requires=[
         'Click',
         'six',
-        'conu>=0.3.0',
         'dockerfile_parse',
         'fmf',
         'PyYAML'

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
         'License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Topic :: Software Development',

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import conu
 from click.testing import CliRunner
 
 from colin.cli.colin import check, list_checks, list_rulesets, info
@@ -130,12 +129,9 @@ def test_info():
     assert __version__ in output[0]
     assert "cli/colin.py" in output[1]
 
-    assert output[3].startswith("conu")
-    assert conu.version in output[3]
-    assert output[3].endswith("/conu")
-    assert output[4].startswith("podman")
-    assert output[5].startswith("skopeo")
-    assert output[6].startswith("ostree")
+    assert output[3].startswith("podman")
+    assert output[4].startswith("skopeo")
+    assert output[5].startswith("ostree")
 
 
 def test_env():


### PR DESCRIPTION
- Remove Python2 from setup.py.
    - Is there anything else that needs to be done in specfile?
- Allow metadata checks for podman images.
- Remove conu for now.
   - We can add it later with move to the conu-podman backend.