### PR TITLE
check_runner: Allow to overwrite timeout in result_set

### DIFF
--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -9,6 +9,7 @@ RUN dnf install -y \
     && dnf clean all
 
 RUN sed '/^graphroot/s/.*/graphroot="\/var\/tmp\/containers"/' -i /etc/containers/storage.conf \
+    && sed -e '/mountopt/s/,\?metacopy=on,\?//' -i /etc/containers/storage.conf \
     && printf 'checkout_path: /var/tmp/containers/atomic\n' >>/etc/atomic.conf
 
 # # podman

--- a/colin/core/check_runner.py
+++ b/colin/core/check_runner.py
@@ -37,12 +37,12 @@ def _result_generator(target, checks, timeout=None):
         for check in checks:
             logger.debug("Checking {}".format(check.name))
             try:
-                timeout = timeout or check.timeout or CHECK_TIMEOUT
-                logger.debug("Check timeout: {}".format(timeout))
-                yield exit_after(timeout)(check.check)(target)
+                _timeout = timeout or check.timeout or CHECK_TIMEOUT
+                logger.debug("Check timeout: {}".format(_timeout))
+                yield exit_after(_timeout)(check.check)(target)
             except TimeoutError as ex:
                 logger.warning(
-                    "The check hit the timeout.")
+                    "The check hit the timeout: {}".format(_timeout))
                 yield FailedCheckResult(check, logs=[str(ex)])
             except Exception as ex:
                 tb = traceback.format_exc()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -42,7 +42,7 @@ def _common_help_options(result):
 def test_check_command():
     result = _call_colin(check)
     expected_output1 = "Usage: check [OPTIONS] TARGET"
-    expected_output2 = 'Error: Missing argument "TARGET"'
+    expected_output2 = "Error: Missing argument 'TARGET'"
     assert result.exit_code == 2
     assert expected_output1 in result.output
     assert expected_output2 in result.output


### PR DESCRIPTION
```
timeout = timeout or check.timeout or CHECK_TIMEOUT
```

Timeout for checks was based on 3 different values.
a) argument `timeout` which was passed from command line --timeout
b) timeout specified in check in result_set
c) predefined default value `CHECK_TIMEOUT`

The bug was that value of argument was changed in the function
and there is nothing like pass by value in python.

Right timeout was used for the 1st check but not for others.

@lachmanfrantisek @TomasTomecek PTAL