### PR TITLE
Add function to convert results to an xunit xml file

### DIFF
--- a/colin/cli/colin.py
+++ b/colin/cli/colin.py
@@ -59,6 +59,8 @@ def cli():
               help="Enable debugging mode (debugging logs, full tracebacks).")
 @click.option('--json', type=click.File(mode='w'),
               help="File to save the output as json to.")
+@click.option('--xunit', type=click.File(mode='w'),
+              help="File to save the output as xunit to.")
 @click.option('--stat', is_flag=True,
               help="Print statistics instead of full results.")
 @click.option('--skip', '-s', multiple=True, type=click.STRING,
@@ -80,7 +82,7 @@ def cli():
               help="Timeout for each check in seconds. (default=600)")
 @click.option('--insecure', is_flag=True, default=False,
               help="Pull from an insecure registry (HTTP or invalid TLS).")
-def check(target, parent_target, ruleset, ruleset_file, debug, json, stat, skip, tag, verbose,
+def check(target, parent_target, ruleset, ruleset_file, debug, json, xunit, stat, skip, tag, verbose,
           checks_paths, target_type, timeout, pull, insecure):
     """
     Check the image/dockerfile (default).
@@ -92,6 +94,10 @@ def check(target, parent_target, ruleset, ruleset_file, debug, json, stat, skip,
     if json and not os.path.isdir(os.path.dirname(os.path.realpath(json.name))):
         raise click.BadOptionUsage(
             "Parent directory for the json output file does not exist.")
+
+    if xunit and not os.path.isdir(os.path.dirname(os.path.realpath(xunit.name))):
+        raise click.BadOptionUsage(
+            "Parent directory for the xunit output file does not exist.")
 
     try:
         if not debug:
@@ -117,6 +123,9 @@ def check(target, parent_target, ruleset, ruleset_file, debug, json, stat, skip,
 
         if json:
             results.save_json_to_file(file=json)
+
+        if xunit:
+            results.save_xunit_to_file(file=xunit)
 
         if not results.ok:
             sys.exit(1)

--- a/colin/cli/colin.py
+++ b/colin/cli/colin.py
@@ -82,8 +82,8 @@ def cli():
               help="Timeout for each check in seconds. (default=600)")
 @click.option('--insecure', is_flag=True, default=False,
               help="Pull from an insecure registry (HTTP or invalid TLS).")
-def check(target, parent_target, ruleset, ruleset_file, debug, json, xunit, stat, skip, tag, verbose,
-          checks_paths, target_type, timeout, pull, insecure):
+def check(target, parent_target, ruleset, ruleset_file, debug, json, xunit, stat, skip, tag,
+          verbose, checks_paths, target_type, timeout, pull, insecure):
     """
     Check the image/dockerfile (default).
     """

--- a/colin/core/result.py
+++ b/colin/core/result.py
@@ -15,7 +15,7 @@
 #
 
 import json
-from xml.etree.ElementTree import Element, SubElement, ElementTree, tostring
+from xml.etree.ElementTree import Element, SubElement, tostring
 from xml.dom import minidom
 
 import six
@@ -119,7 +119,7 @@ class CheckResults(object):
                 'status': "PASSED" if r.ok else "FAILED",
                 'url': r.reference_url
             })
-            if len(r.logs) > 0:
+            if r.logs:
                 logs = SubElement(testcase, "logs")
                 for log in r.logs:
                     log = SubElement(logs, "log", {
@@ -134,6 +134,11 @@ class CheckResults(object):
         return reparsed.toprettyxml(indent="  ")
 
     def save_xunit_to_file(self, file):
+        """
+        Write the contents of xunit to the passed file pointer.
+        :param file: the file to which to write
+        :return: return code of the write command
+        """
         file.write(self.xunit)
 
     @property

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -34,6 +34,7 @@ def _common_help_options(result):
     assert "-f, --ruleset-file FILENAME" in result.output
     assert "--debug" in result.output
     assert "--json FILENAME" in result.output
+    assert "--xunit FILENAME" in result.output
     assert "-t, --tag TEXT" in result.output
     assert "-v, --verbose" in result.output
     assert "-h, --help" in result.output

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -34,7 +34,6 @@ def _common_help_options(result):
     assert "-f, --ruleset-file FILENAME" in result.output
     assert "--debug" in result.output
     assert "--json FILENAME" in result.output
-    assert "--xunit FILENAME" in result.output
     assert "-t, --tag TEXT" in result.output
     assert "-v, --verbose" in result.output
     assert "-h, --help" in result.output
@@ -54,6 +53,7 @@ def test_check_help_command():
     assert result.exit_code == 0
     _common_help_options(result)
     assert "--stat" in result.output
+    assert "--xunit FILENAME" in result.output
 
 
 def test_list_checks():


### PR DESCRIPTION
Adds a function so that the test results are outputted as an xunit xml file that can be parsed by things that support it. 