### PR TITLE
Fix CONTRIBUTING.md to reflect correct CLI args

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,9 +157,9 @@ $ cat foobar.json
 }
 ```
 
-And we would just call colin and point it to `/tmp/external_checks/checks.py`:
+And we would just call colin and point it to the directory containing python files with checks:
 ```
-$ python3 -m colin.cli.colin -f ./foobar.json --checks-path /tmp/external_checks/checks.py fedora:28
+$ python3 -m colin.cli.colin -f ./foobar.json --checks-path /tmp/external_checks/ fedora:28
 10:43:38.165 loader.py         DEBUG  Getting check(s) from the file '/tmp/external_checks/checks.py'.
 10:43:38.165 loader.py         DEBUG  Will try to load selected file as module 'checks'.
 10:43:38.168 ruleset.py        DEBUG  Check instance foobar_file_required added.


### PR DESCRIPTION
Currently, the directions in `CONTRIBUTING.md` tell users to point the
`--checks-path` CLI option to an external file,
`/tmp/external_checks/checks.py`. This is inconsistent with the current
`--checks-path` functionality and CLI help menu description which states
that the `--checks-path` option should point to a "directory containing
checks."

This fix to `CONTRIBUTING.md` is intended to clear up any confusion for
new users of the project.

Signed-off-by: Rose Judge <rjudge@vmware.com>