### PR TITLE
Add OCI support for unprivileged checks

### DIFF
--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -6,7 +6,9 @@ RUN dnf install -y \
     make python3-pytest python3-pyxattr python3-pytest-cov \
     skopeo podman buildah atomic \
     python3-ipdb \
-    && dnf clean all
+    && dnf clean all \
+    && curl -L -o /usr/local/bin/umoci https://github.com/opencontainers/umoci/releases/download/v0.4.6/umoci.amd64 \
+    && chmod a+x /usr/local/bin/umoci
 
 RUN sed '/^graphroot/s/.*/graphroot="\/var\/tmp\/containers"/' -i /etc/containers/storage.conf \
     && sed -e '/mountopt/s/,\?metacopy=on,\?//' -i /etc/containers/storage.conf \

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:29
+FROM docker.io/fedora:29
 
 ENV PYTHONDONTWRITEBYTECODE=yes-please
 

--- a/colin/cli/colin.py
+++ b/colin/cli/colin.py
@@ -77,7 +77,7 @@ def cli():
               help="Pull the image from registry.")
 @click.option('--target-type', type=click.STRING, default="image",
               help="Type of selected target (one of image, dockerfile, "
-                   "ostree). For ostree, please specify image name and path like this: image@path")
+                   "ostree, oci). For ostree, please specify image name and path like this: image@path")
 @click.option('--timeout', type=click.INT,
               help="Timeout for each check in seconds. (default=600)")
 @click.option('--insecure', is_flag=True, default=False,
@@ -245,6 +245,8 @@ def info():
     click.echo(get_version_msg_from_the_cmd(package_name="ostree",
                                             use_rpm=rpm_installed,
                                             max_lines_of_the_output=3))
+    click.echo(get_version_msg_from_the_cmd(package_name="umoci",
+                                            use_rpm=rpm_installed))
 
 
 cli.add_command(check)

--- a/colin/core/colin.py
+++ b/colin/core/colin.py
@@ -43,7 +43,7 @@ def run(
 
     :param timeout: timeout per-check (in seconds)
     :param skips: name of checks to skip
-    :param target: str (image name, ostree or dockertar)
+    :param target: str (image name, ostree, oci, or dockertar)
                     or ImageTarget
                     or path/file-like object for dockerfile
     :param parent_target: Target for parent image

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import tempfile
 import pytest
 
 from colin.core.colin import _set_logging
-from colin.core.target import ImageTarget, OstreeTarget, DockerfileTarget
+from colin.core.target import ImageTarget, OstreeTarget, OciTarget, DockerfileTarget
 
 _set_logging(level=logging.DEBUG)
 
@@ -66,6 +66,17 @@ def convert_image_to_ostree(image_name):
     return ostree_path
 
 
+def convert_image_to_oci(image_name):
+    tmpdir_path = tempfile.mkdtemp(prefix="pytest-", dir="/var/tmp")
+    oci_path = os.path.join(tmpdir_path, "oci")
+    os.makedirs(oci_path)
+    skopeo_target = get_skopeo_oci_target(image_name=image_name, oci_path=oci_path)
+
+    cmd = ["podman", "push", image_name, skopeo_target]
+    subprocess.check_call(cmd)
+    return oci_path
+
+
 def get_target(name, type):
     if type == "image":
 
@@ -85,6 +96,17 @@ def get_target(name, type):
         ostree_target.clean_up()
         shutil.rmtree(ostree_path)
 
+    elif type == "oci":
+
+        oci_path = convert_image_to_oci(name)
+        skopeo_target = get_skopeo_oci_target(image_name=name,
+                                              oci_path=oci_path)
+
+        oci_target = OciTarget(target=skopeo_target)
+        yield oci_target
+        oci_target.clean_up()
+        shutil.rmtree(oci_path)
+
     elif type == "dockerfile":
 
         this_dir = os.path.abspath(os.path.dirname(__file__))
@@ -98,13 +120,17 @@ def get_skopeo_path(image_name, ostree_path):
     return "ostree:%s@%s" % (image_name, ostree_path)
 
 
+def get_skopeo_oci_target(image_name, oci_path):
+    return "oci:%s:%s" % (oci_path, image_name)
+
+
 @pytest.fixture(scope="session", autouse=True)
 def label_image():
     build_image_if_not_exists(LABELS_IMAGE)
 
 
 @pytest.fixture(scope="session",
-                params=["image", "ostree", "dockerfile"])
+                params=["image", "ostree", "oci", "dockerfile"])
 def target_label(request, label_image):
     for t in get_target(name=LABELS_IMAGE,
                         type=request.param):
@@ -112,7 +138,7 @@ def target_label(request, label_image):
 
 
 @pytest.fixture(scope="session",
-                params=["image", "ostree", "dockerfile"])
+                params=["image", "ostree", "oci", "dockerfile"])
 def target_label_image_and_dockerfile(request, label_image):
     for t in get_target(name=LABELS_IMAGE,
                         type=request.param):
@@ -125,7 +151,7 @@ def target_bash_image():
 
 
 @pytest.fixture(scope="session",
-                params=["image", "ostree"])
+                params=["image", "ostree", "oci"])
 def target_bash(request, target_bash_image):
     for t in get_target(name=BASH_IMAGE,
                         type=request.param):
@@ -138,7 +164,7 @@ def target_ls_image():
 
 
 @pytest.fixture(scope="session",
-                params=["image", "ostree"])
+                params=["image", "ostree", "oci"])
 def target_ls(request, target_ls_image):
     for t in get_target(name=LS_IMAGE,
                         type=request.param):
@@ -160,7 +186,7 @@ def target_busybox_image():
 
 
 @pytest.fixture(scope="session",
-                params=["image", "ostree"])
+                params=["image", "ostree", "oci"])
 def target_busybox(request, target_busybox_image):
     for t in get_target(name=BUSYBOX_IMAGE,
                         type=request.param):

--- a/tests/integration/test_targets.py
+++ b/tests/integration/test_targets.py
@@ -5,7 +5,7 @@ Test different target types.
 import pytest
 
 import colin
-from tests.conftest import LABELS_IMAGE, convert_image_to_ostree, get_skopeo_path
+from tests.conftest import LABELS_IMAGE, convert_image_to_ostree, get_skopeo_path, convert_image_to_oci, get_skopeo_oci_target
 
 
 @pytest.fixture()
@@ -112,5 +112,14 @@ def test_ostree_target(ruleset):
     ostree_path = convert_image_to_ostree(image_name=image_name)
     skopeo_target = get_skopeo_path(image_name=image_name, ostree_path=ostree_path)
     results = colin.run(skopeo_target, "ostree", ruleset=ruleset, logging_level=10, pull=False)
+    assert results.ok
+    assert results.results_per_check["url_label"].ok
+
+
+def test_oci_target(ruleset):
+    image_name = "colin-labels"
+    oci_path = convert_image_to_oci(image_name=image_name)
+    skopeo_target = get_skopeo_oci_target(image_name=image_name, oci_path=oci_path)
+    results = colin.run(skopeo_target, "oci", ruleset=ruleset, logging_level=10, pull=False)
     assert results.ok
     assert results.results_per_check["url_label"].ok

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -131,6 +131,7 @@ def test_info():
     assert output[3].startswith("podman")
     assert output[4].startswith("skopeo")
     assert output[5].startswith("ostree")
+    assert output[6].startswith("umoci")
 
 
 def test_env():


### PR DESCRIPTION
The support for ostree was removed from skopeo in fedora 31 and from podman in fedora 30.
