### PR TITLE
Use fstrings and avoid templating in logger

### DIFF
--- a/colin/checks/best_practices.py
+++ b/colin/checks/best_practices.py
@@ -30,7 +30,7 @@ class CmdOrEntrypointCheck(FMFAbstractCheck, ImageAbstractCheck):
     def check(self, target):
         metadata = target.config_metadata["ContainerConfig"]
         cmd_present = "Cmd" in metadata and metadata["Cmd"]
-        msg_cmd_present = "Cmd {}specified.".format("" if cmd_present else "not ")
+        msg_cmd_present = f"Cmd {'' if cmd_present else 'not '}specified."
         logger.debug(msg_cmd_present)
 
         entrypoint_present = "Entrypoint" in metadata and metadata["Entrypoint"]

--- a/colin/cli/colin.py
+++ b/colin/cli/colin.py
@@ -91,7 +91,7 @@ def cli():
     type=click.Path(exists=True, dir_okay=True, file_okay=False),
     multiple=True,
     envvar=COLIN_CHECKS_PATH,
-    help="Path to directory containing checks (default {}).".format(get_checks_paths()),
+    help=f"Path to directory containing checks (default {get_checks_paths()}).",
 )
 @click.option("--pull", is_flag=True, help="Pull the image from registry.")
 @click.option(
@@ -233,7 +233,7 @@ def check(
     type=click.Path(exists=True, dir_okay=True, file_okay=False),
     multiple=True,
     envvar=COLIN_CHECKS_PATH,
-    help="Path to directory containing checks (default {}).".format(get_checks_paths()),
+    help=f"Path to directory containing checks (default {get_checks_paths()}).",
 )
 def list_checks(ruleset, ruleset_file, debug, json, skip, tag, verbose, checks_paths):
     """
@@ -308,8 +308,8 @@ def info():
         os.path.join(os.path.dirname(__file__), os.path.pardir)
     )
 
-    click.echo("colin {} {}".format(__version__, installation_path))
-    click.echo("colin-cli {}\n".format(os.path.realpath(__file__)))
+    click.echo(f"colin {__version__} {installation_path}")
+    click.echo(f"colin-cli {os.path.realpath(__file__)}\n")
 
     # click.echo(get_version_of_the_python_package(module=conu))
 

--- a/colin/core/check_runner.py
+++ b/colin/core/check_runner.py
@@ -33,19 +33,17 @@ def go_through_checks(target, checks, timeout=None):
 def _result_generator(target, checks, timeout=None):
     try:
         for check in checks:
-            logger.debug("Checking {}".format(check.name))
+            logger.debug("Checking %s", check.name)
             try:
                 _timeout = timeout or check.timeout or CHECK_TIMEOUT
-                logger.debug("Check timeout: {}".format(_timeout))
+                logger.debug("Check timeout: %s", _timeout)
                 yield exit_after(_timeout)(check.check)(target)
             except TimeoutError as ex:
-                logger.warning("The check hit the timeout: {}".format(_timeout))
+                logger.warning("The check hit the timeout: %s", _timeout)
                 yield FailedCheckResult(check, logs=[str(ex)])
             except Exception as ex:
                 tb = traceback.format_exc()
-                logger.warning(
-                    "There was an error while performing check: {}".format(tb)
-                )
+                logger.warning("There was an error while performing check: %s", tb)
                 yield FailedCheckResult(check, logs=[str(ex)])
     finally:
         target.clean_up()

--- a/colin/core/checks/abstract_check.py
+++ b/colin/core/checks/abstract_check.py
@@ -35,17 +35,11 @@ class AbstractCheck:
 
     def __str__(self):
         return (
-            "{}\n"
-            "   -> {}\n"
-            "   -> {}\n"
-            "   -> {}\n"
-            "   -> {}\n".format(
-                self.name,
-                self.message,
-                self.description,
-                self.reference_url,
-                ", ".join(self.tags),
-            )
+            f"{self.name}\n"
+            f"   -> {self.message}\n"
+            f"   -> {self.description}\n"
+            f"   -> {self.reference_url}\n"
+            f"   -> {', '.join(self.tags)}\n"
         )
 
     @property

--- a/colin/core/checks/check_utils.py
+++ b/colin/core/checks/check_utils.py
@@ -40,7 +40,7 @@ class NotLoadedCheck(DockerfileAbstractCheck, ImageAbstractCheck):
     def __init__(self, check_name, reason):
         self.name = check_name
         super(NotLoadedCheck, self).__init__(
-            message="Check code '{}' {}.".format(check_name, reason),
+            message=f"Check code '{check_name}' {reason}.",
             description="Did you set the right name in the ruleset file?",
             reference_url="",
             tags=[],

--- a/colin/core/checks/cmd.py
+++ b/colin/core/checks/cmd.py
@@ -79,9 +79,7 @@ class CmdAbstractCheck(ImageAbstractCheck):
         if self.expected_output is not None:
             expected_output = self.expected_output == output
             if expected_output:
-                logs.append(
-                    f"ok: Output of the command '{self.cmd}' was as expected."
-                )
+                logs.append(f"ok: Output of the command '{self.cmd}' was as expected.")
             else:
                 logs.append(
                     "nok: Output of the command '{}' "

--- a/colin/core/checks/cmd.py
+++ b/colin/core/checks/cmd.py
@@ -63,7 +63,7 @@ class CmdAbstractCheck(ImageAbstractCheck):
         except ColinException as ex:
             return FailedCheckResult(check=self, logs=[str(ex)])
         passed = True
-        logs = ["Output:\n{}".format(output)]
+        logs = [f"Output:\n{output}"]
         if self.substring is not None:
             substring_present = self.substring in output
             passed = passed and substring_present
@@ -80,8 +80,7 @@ class CmdAbstractCheck(ImageAbstractCheck):
             expected_output = self.expected_output == output
             if expected_output:
                 logs.append(
-                    "ok: Output of the command '{}' "
-                    "was as expected.".format(self.cmd)
+                    f"ok: Output of the command '{self.cmd}' was as expected."
                 )
             else:
                 logs.append(

--- a/colin/core/checks/cmd.py
+++ b/colin/core/checks/cmd.py
@@ -82,10 +82,8 @@ class CmdAbstractCheck(ImageAbstractCheck):
                 logs.append(f"ok: Output of the command '{self.cmd}' was as expected.")
             else:
                 logs.append(
-                    "nok: Output of the command '{}' "
-                    "does not match the expected one: '{}'.".format(
-                        self.cmd, self.expected_output
-                    )
+                    f"nok: Output of the command '{self.cmd}' "
+                    f"does not match the expected one: '{self.expected_output}'."
                 )
 
                 passed = False
@@ -94,14 +92,13 @@ class CmdAbstractCheck(ImageAbstractCheck):
             pattern = re.compile(self.expected_regex)
             if pattern.match(output):
                 logs.append(
-                    "ok: Output of the command '{}' match the regex '{}'.".format(
-                        self.cmd, self.expected_regex
-                    )
+                    f"ok: Output of the command '{self.cmd}' "
+                    f"match the regex '{self.expected_regex}'."
                 )
             else:
                 logs.append(
-                    "nok: Output of the command '{}' does not match"
-                    " the expected regex: '{}'.".format(self.cmd, self.expected_regex)
+                    f"nok: Output of the command '{self.cmd}' does not match"
+                    f" the expected regex: '{self.expected_regex}'."
                 )
 
                 passed = False

--- a/colin/core/checks/filesystem.py
+++ b/colin/core/checks/filesystem.py
@@ -38,9 +38,7 @@ class FileCheck(ImageAbstractCheck):
         for f in self.files:
             try:
                 f_present = target.file_is_present(f)
-                logs.append(
-                    f"File '{f}' is {'' if f_present else 'not '}present."
-                )
+                logs.append(f"File '{f}' is {'' if f_present else 'not '}present.")
             except IOError as ex:
                 logger.info("File %s is not present, ex: %s", f, ex)
                 f_present = False
@@ -71,9 +69,7 @@ class FileCheck(ImageAbstractCheck):
             cmd = ["/bin/ls", "-1", f]
             try:
                 f_present = cont.execute(cmd)
-                logs.append(
-                    f"File '{f}' is {'' if f_present else 'not '}present."
-                )
+                logs.append(f"File '{f}' is {'' if f_present else 'not '}present.")
             except Exception as ex:
                 logger.info("File %s is not present, ex: %s", f, ex)
                 f_present = False

--- a/colin/core/checks/filesystem.py
+++ b/colin/core/checks/filesystem.py
@@ -39,12 +39,12 @@ class FileCheck(ImageAbstractCheck):
             try:
                 f_present = target.file_is_present(f)
                 logs.append(
-                    "File '{}' is {}present.".format(f, "" if f_present else "not ")
+                    f"File '{f}' is {'' if f_present else 'not '}present."
                 )
             except IOError as ex:
                 logger.info("File %s is not present, ex: %s", f, ex)
                 f_present = False
-                logs.append("File {} is not present.".format(f))
+                logs.append(f"File {f} is not present.")
             if self.all_must_be_present:
                 passed = f_present and passed
             else:
@@ -72,12 +72,12 @@ class FileCheck(ImageAbstractCheck):
             try:
                 f_present = cont.execute(cmd)
                 logs.append(
-                    "File '{}' is {}present.".format(f, "" if f_present else "not ")
+                    f"File '{f}' is {'' if f_present else 'not '}present."
                 )
             except Exception as ex:
                 logger.info("File %s is not present, ex: %s", f, ex)
                 f_present = False
-                logs.append("File {} is not present.".format(f))
+                logs.append(f"File {f} is not present.")
             if self.all_must_be_present:
                 passed = f_present and passed
             else:

--- a/colin/core/checks/fmf_check.py
+++ b/colin/core/checks/fmf_check.py
@@ -40,7 +40,7 @@ def receive_fmf_metadata(name, path, object_list=False):
             )
         )
     elif not items:
-        raise Exception("Unable to get FMF metadata for: {}".format(name))
+        raise Exception(f"Unable to get FMF metadata for: {name}")
     return output
 
 

--- a/colin/core/checks/labels.py
+++ b/colin/core/checks/labels.py
@@ -121,7 +121,7 @@ class InheritedOptionalLabelAbstractCheck(ImageAbstractCheck):
             for label in labels_to_check:
                 if target.labels[label] == target.parent_target.labels[label]:
                     passed = False
-                    log = "optional label inherited: {}".format(label)
+                    log = f"optional label inherited: {label}"
                     logs.append(log)
                     logger.debug(log)
 

--- a/colin/core/fmf_extension.py
+++ b/colin/core/fmf_extension.py
@@ -63,7 +63,7 @@ class ExtendedTree(Tree):
             # match same item
             reference_node = None
             for datatree in datatrees:
-                reference_node = datatree.search("[^@]%s" % ref_item_name)
+                reference_node = datatree.search(f"[^@]{ref_item_name}")
                 if reference_node is not None:
                     break
             if not reference_node:

--- a/colin/core/loader.py
+++ b/colin/core/loader.py
@@ -68,7 +68,7 @@ def should_we_load(kls):
 
 
 def load_check_classes_from_file(path):
-    logger.debug("Getting check(s) from the file '{}'.".format(path))
+    logger.debug("Getting check(s) from the file '%s'.", path)
     m = _load_module(path)
 
     check_classes = []

--- a/colin/core/loader.py
+++ b/colin/core/loader.py
@@ -99,7 +99,7 @@ class CheckLoader(object):
         logger.debug("Will load checks from paths '%s'.", checks_paths)
         for p in checks_paths:
             if os.path.isfile(p):
-                raise RuntimeError("Provided path %s is not a directory." % p)
+                raise RuntimeError(f"Provided path {p} is not a directory.")
         self._check_classes = None
         self._mapping = None
         self.paths = checks_paths

--- a/colin/core/result.py
+++ b/colin/core/result.py
@@ -210,9 +210,7 @@ class CheckResults(object):
                     if logs and r.logs:
                         output_function("  -> logs:", fg=COLOURS[r.status])
                         for line in r.logs:
-                            output_function(
-                                f"    -> {line}", fg=COLOURS[r.status]
-                            )
+                            output_function(f"    -> {line}", fg=COLOURS[r.status])
 
         if not has_check:
             output_function("No check found.")

--- a/colin/core/result.py
+++ b/colin/core/result.py
@@ -38,7 +38,7 @@ class CheckResult(object):
         return PASSED if self.ok else FAILED
 
     def __str__(self):
-        return "{}:{}".format(self.status, self.message)
+        return f"{self.status}:{self.message}"
 
 
 class DockerfileCheckResult(CheckResult):
@@ -204,14 +204,14 @@ class CheckResults(object):
                 output_function(str(r), fg=COLOURS[r.status])
                 if verbose:
                     output_function(
-                        "  -> {}\n" "  -> {}".format(r.description, r.reference_url),
+                        f"  -> {r.description}\n  -> {r.reference_url}",
                         fg=COLOURS[r.status],
                     )
                     if logs and r.logs:
                         output_function("  -> logs:", fg=COLOURS[r.status])
                         for line in r.logs:
                             output_function(
-                                "    -> {}".format(line), fg=COLOURS[r.status]
+                                f"    -> {line}", fg=COLOURS[r.status]
                             )
 
         if not has_check:
@@ -221,7 +221,7 @@ class CheckResults(object):
         else:
             output_function("")
             for status, count in six.iteritems(self.statistics):
-                output_function("{}:{} ".format(status, count), nl=False)
+                output_function(f"{status}:{count} ", nl=False)
             output_function("")
 
     def get_pretty_string(self, stat, verbose):

--- a/colin/core/ruleset/loader.py
+++ b/colin/core/ruleset/loader.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 def get_ruleset_struct_from_fileobj(fileobj):
     try:
-        logger.debug(f"Loading ruleset from file '{fileobj.name}'.")
+        logger.debug("Loading ruleset from file '%s'.", fileobj.name)
         return RulesetStruct(yaml.safe_load(fileobj))
     except Exception as ex:
         msg = f"Ruleset file '{fileobj.name}' cannot be loaded: {ex}"

--- a/colin/core/ruleset/loader.py
+++ b/colin/core/ruleset/loader.py
@@ -27,10 +27,10 @@ logger = logging.getLogger(__name__)
 
 def get_ruleset_struct_from_fileobj(fileobj):
     try:
-        logger.debug("Loading ruleset from file '{}'.".format(fileobj.name))
+        logger.debug(f"Loading ruleset from file '{fileobj.name}'.")
         return RulesetStruct(yaml.safe_load(fileobj))
     except Exception as ex:
-        msg = "Ruleset file '{}' cannot be loaded: {}".format(fileobj.name, ex)
+        msg = f"Ruleset file '{fileobj.name}' cannot be loaded: {ex}"
         logger.error(msg)
         raise ColinRulesetException(msg)
 
@@ -42,7 +42,7 @@ def get_ruleset_struct_from_file(file_path):
     except ColinRulesetException as ex:
         raise ex
     except Exception as ex:
-        msg = "Ruleset '{}' cannot be loaded: {}".format(file_path, ex)
+        msg = f"Ruleset '{file_path}' cannot be loaded: {ex}"
 
         logger.error(msg)
         raise ColinRulesetException(msg)
@@ -71,7 +71,7 @@ def nicer_get(di, required, *path):
                 )
                 logger.debug("full dict = %s", r)
                 raise ColinRulesetException(
-                    "Validation error: can't locate %s in ruleset." % p
+                    f"Validation error: can't locate {p} in ruleset."
                 )
             return
     return r
@@ -96,7 +96,7 @@ class CheckStruct(object):
         return nicer_get(self.c, required, *path)
 
     def __str__(self):
-        return "%s" % self.name
+        return f"{self.name}"
 
     @property
     def import_name(self):
@@ -154,7 +154,7 @@ class RulesetStruct(object):
         return nicer_get(self.d, True, *path)
 
     def __str__(self):
-        return "%s" % self.name
+        return f"{self.name}"
 
     @property
     def version(self):

--- a/colin/core/ruleset/ruleset.py
+++ b/colin/core/ruleset/ruleset.py
@@ -49,7 +49,7 @@ class Ruleset(object):
         elif ruleset_file:
             self.ruleset_struct = get_ruleset_struct_from_fileobj(ruleset_file)
         else:
-            logger.debug("Loading ruleset with the name '{}'.".format(ruleset_name))
+            logger.debug("Loading ruleset with the name '%s'.", ruleset_name)
             ruleset_path = get_ruleset_file(ruleset=ruleset_name)
             self.ruleset_struct = get_ruleset_struct_from_file(ruleset_path)
         if self.ruleset_struct.version not in ["1", 1]:
@@ -73,7 +73,7 @@ class Ruleset(object):
             if check_struct.name in skips:
                 continue
 
-            logger.debug("Processing check_struct {}.".format(check_struct))
+            logger.debug("Processing check_struct %s.", check_struct)
 
             usable_targets = check_struct.usable_targets
             if (
@@ -132,9 +132,9 @@ class Ruleset(object):
             if tags:
                 if not set(tags) < set(check_instance.tags):
                     logger.debug(
-                        "Check '{}' not passed the tag control: {}".format(
-                            check_instance.name, tags
-                        )
+                        "Check '%s' not passed the tag control: %s",
+                        check_instance.name,
+                        tags,
                     )
                     continue
 
@@ -144,7 +144,7 @@ class Ruleset(object):
                 setattr(check_instance, k, v)
 
             result.append(check_instance)
-            logger.debug("Check instance {} added.".format(check_instance.name))
+            logger.debug("Check instance %s added.", check_instance.name)
 
         return result
 
@@ -181,17 +181,13 @@ def get_ruleset_file(ruleset=None):
 
         for ruleset_file in possible_ruleset_files:
             if os.path.isfile(ruleset_file):
-                logger.debug("Ruleset file '{}' found.".format(ruleset_file))
+                logger.debug("Ruleset file '%s' found.", ruleset_file)
                 return ruleset_file
 
     logger.warning(
-        "Ruleset with the name '{}' cannot be found at '{}'.".format(
-            ruleset, ruleset_dirs
-        )
+        "Ruleset with the name '%s' cannot be found at '%s'.", ruleset, ruleset_dirs
     )
-    raise ColinRulesetException(
-        f"Ruleset with the name '{ruleset}' cannot be found."
-    )
+    raise ColinRulesetException(f"Ruleset with the name '{ruleset}' cannot be found.")
 
 
 def get_ruleset_dirs():
@@ -208,7 +204,7 @@ def get_ruleset_dirs():
     cwd_rulesets = os.path.join(".", RULESET_DIRECTORY_NAME)
     if os.path.isdir(cwd_rulesets):
         logger.debug(
-            "Ruleset directory found in current directory ('{}').".format(cwd_rulesets)
+            "Ruleset directory found in current directory ('%s').", cwd_rulesets
         )
         ruleset_dirs.append(cwd_rulesets)
 
@@ -216,18 +212,18 @@ def get_ruleset_dirs():
         venv_local_share = os.path.join(os.environ["VIRTUAL_ENV"], RULESET_DIRECTORY)
         if os.path.isdir(venv_local_share):
             logger.debug(
-                "Virtual env ruleset directory found ('{}').".format(venv_local_share)
+                "Virtual env ruleset directory found ('%s').", venv_local_share
             )
             ruleset_dirs.append(venv_local_share)
 
     local_share = os.path.join(os.path.expanduser("~"), ".local", RULESET_DIRECTORY)
     if os.path.isdir(local_share):
-        logger.debug("Local ruleset directory found ('{}').".format(local_share))
+        logger.debug("Local ruleset directory found ('%s').", local_share)
         ruleset_dirs.append(local_share)
 
     usr_local_share = os.path.join("/usr/local", RULESET_DIRECTORY)
     if os.path.isdir(usr_local_share):
-        logger.debug("Global ruleset directory found ('{}').".format(usr_local_share))
+        logger.debug("Global ruleset directory found ('%s').", usr_local_share)
         ruleset_dirs.append(usr_local_share)
 
     if not ruleset_dirs:

--- a/colin/core/ruleset/ruleset.py
+++ b/colin/core/ruleset/ruleset.py
@@ -96,9 +96,7 @@ class Ruleset(object):
                         check_struct.name,
                     )
                     raise ColinRulesetException(
-                        "Check {} can't be loaded, we couldn't find it.".format(
-                            check_struct.name
-                        )
+                        f"Check {check_struct.name} can't be loaded, we couldn't find it."
                     )
             check_instance = check_class()
 
@@ -117,16 +115,13 @@ class Ruleset(object):
                 target_type=target_type, check_instance=check_instance
             ):
                 logger.error(
-                    "Check '{}' not compatible with the target type: {}".format(
-                        check_instance.name,
-                        target_type.get_compatible_check_class().check_type,
-                    )
+                    "Check '%s' not compatible with the target type: %s",
+                    check_instance.name,
+                    target_type.get_compatible_check_class().check_type,
                 )
                 raise ColinRulesetException(
-                    "Check {} can't be used for target type {}".format(
-                        check_instance,
-                        target_type.get_compatible_check_class().check_type,
-                    )
+                    f"Check {check_instance} can't be used for target type "
+                    f"{target_type.get_compatible_check_class().check_type}"
                 )
 
             if tags:

--- a/colin/core/ruleset/ruleset.py
+++ b/colin/core/ruleset/ruleset.py
@@ -190,7 +190,7 @@ def get_ruleset_file(ruleset=None):
         )
     )
     raise ColinRulesetException(
-        "Ruleset with the name '{}' cannot be found.".format(ruleset)
+        f"Ruleset with the name '{ruleset}' cannot be found."
     )
 
 

--- a/colin/core/target.py
+++ b/colin/core/target.py
@@ -285,7 +285,7 @@ class ImageTarget(AbstractImageTarget):
         result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if result.returncode == 0:
             self.image_id = result.stdout.decode().rstrip()
-            logger.debug("Image found with id: '{}'.".format(self.image_id))
+            logger.debug("Image found with id: '%s'.", self.image_id)
         else:
             if "unable to find" in result.stderr.decode():
                 if self.pull:
@@ -296,18 +296,14 @@ class ImageTarget(AbstractImageTarget):
                     )
                     if result_pull.returncode == 0:
                         self.image_id = result_pull.stdout.decode().rstrip()
-                        logger.debug(
-                            "Image pulled with id: '{}'.".format(self.image_id)
-                        )
+                        logger.debug("Image pulled with id: '%s'.", self.image_id)
                     else:
                         raise ColinException(
                             f"Cannot pull an image: '{self.target_name}'."
                         )
 
                 else:
-                    raise ColinException(
-                        f"Image '{self.target_name}' not found."
-                    )
+                    raise ColinException(f"Image '{self.target_name}' not found.")
             else:
                 raise ColinException(f"Podman error: {result.stderr}")
 

--- a/colin/core/target.py
+++ b/colin/core/target.py
@@ -183,7 +183,7 @@ class AbstractImageTarget(Target):
         except IOError as ex:
             logger.error("error while accessing file %s: %r", file_path, ex)
             raise ColinException(
-                "There was an error while accessing file %s: %r" % (file_path, ex)
+                f"There was an error while accessing file {file_path}: {ex!r}"
             )
 
     def get_file(self, file_path, mode="r"):
@@ -206,7 +206,7 @@ class AbstractImageTarget(Target):
         if not os.path.exists(real_path):
             return False
         if not os.path.isfile(real_path):
-            raise IOError("%s is not a file" % file_path)
+            raise IOError(f"{file_path} is not a file")
         return True
 
     def cont_path(self, path):
@@ -301,15 +301,15 @@ class ImageTarget(AbstractImageTarget):
                         )
                     else:
                         raise ColinException(
-                            "Cannot pull an image: '{}'.".format(self.target_name)
+                            f"Cannot pull an image: '{self.target_name}'."
                         )
 
                 else:
                     raise ColinException(
-                        "Image '{}' not found.".format(self.target_name)
+                        f"Image '{self.target_name}' not found."
                     )
             else:
-                raise ColinException("Podman error: {}".format(result.stderr))
+                raise ColinException(f"Podman error: {result.stderr}")
 
     def clean_up(self):
         if self._mount_point:
@@ -399,7 +399,7 @@ class OstreeTarget(AbstractImageTarget):
     @property
     def skopeo_target(self):
         """ Skopeo format for the ostree repository. """
-        return "ostree:{}@{}".format(self.ref_image_name, self.ostree_path)
+        return f"ostree:{self.ref_image_name}@{self.ostree_path}"
 
     @property
     def tmpdir(self):
@@ -524,7 +524,7 @@ class OciTarget(AbstractImageTarget):
     @property
     def skopeo_target(self):
         """ Skopeo format for the oci repository. """
-        return "oci:{}:{}".format(self.oci_path, self.ref_image_name)
+        return f"oci:{self.oci_path}:{self.ref_image_name}"
 
     @property
     def tmpdir(self):
@@ -543,7 +543,7 @@ class OciTarget(AbstractImageTarget):
             "unpack",
             "--rootless",
             "--image",
-            "{}:{}".format(self.oci_path, self.ref_image_name),
+            f"{self.oci_path}:{self.ref_image_name}",
             checkout_dir,
         ]
         self._run_and_log(cmd, "Failed to mount selected image as an oci repo.")

--- a/colin/core/target.py
+++ b/colin/core/target.py
@@ -113,8 +113,9 @@ class Target(object):
                 raise
 
         raise ColinException(
-            "Unknown target type '{}'. Please make sure that you picked the correct target type: "
-            "--target-type CLI option.".format(target_type)
+            f"Unknown target type '{target_type}'. "
+            "Please make sure that you picked the correct target type: "
+            "--target-type CLI option."
         )
 
 

--- a/colin/utils/cmd_tools.py
+++ b/colin/utils/cmd_tools.py
@@ -34,10 +34,10 @@ def get_version_of_the_python_package(module):
     :param module: module to show info about
     :return: str 'name version path'
     """
-    return "{} {} {}".format(
-        getattr(module, "__name__", None),
-        getattr(module, "__version__", None),
-        getattr(module, "__path__", [None])[0],
+    return (
+        f"{getattr(module, '__name__', None)} "
+        f"{getattr(module, '__version__', None)} "
+        f"{getattr(module, '__path__', [None])[0]}"
     )
 
 

--- a/colin/utils/cmd_tools.py
+++ b/colin/utils/cmd_tools.py
@@ -119,9 +119,7 @@ def exit_after(s):
             try:
                 result = fn(*args, **kwargs)
             except KeyboardInterrupt:
-                raise TimeoutError(
-                    f"Function '{fn.__name__}' hit the timeout ({s}s)."
-                )
+                raise TimeoutError(f"Function '{fn.__name__}' hit the timeout ({s}s).")
             finally:
                 timer.cancel()
             return result

--- a/colin/utils/cmd_tools.py
+++ b/colin/utils/cmd_tools.py
@@ -58,7 +58,7 @@ def get_version_msg_from_the_cmd(
     if use_rpm:
         rpm_version = get_rpm_version(package_name=package_name)
         if rpm_version:
-            return "{} (rpm)".format(rpm_version)
+            return f"{rpm_version} (rpm)"
 
     try:
         cmd = cmd or [package_name, "--version"]
@@ -74,9 +74,9 @@ def get_version_msg_from_the_cmd(
             return version_output
 
         else:
-            return "{}: cannot get version with {}".format(package_name, cmd)
+            return f"{package_name}: cannot get version with {cmd}"
     except FileNotFoundError:
-        return "{} not accessible!".format(package_name)
+        return f"{package_name} not accessible!"
 
 
 def get_rpm_version(package_name):
@@ -120,7 +120,7 @@ def exit_after(s):
                 result = fn(*args, **kwargs)
             except KeyboardInterrupt:
                 raise TimeoutError(
-                    "Function '{}' hit the timeout ({}s).".format(fn.__name__, s)
+                    f"Function '{fn.__name__}' hit the timeout ({s}s)."
                 )
             finally:
                 timer.cancel()

--- a/colin/utils/cont.py
+++ b/colin/utils/cont.py
@@ -55,10 +55,8 @@ class ImageName(object):
 
     def __str__(self):
         return (
-            "Image: registry='{}' namespace='{}' "
-            "repository='{}' tag='{}' digest='{}'".format(
-                self.registry, self.namespace, self.repository, self.tag, self.digest
-            )
+            f"Image: registry='{self.registry}' namespace='{self.namespace}' "
+            f"repository='{self.repository}' tag='{self.tag}' digest='{self.digest}'"
         )
 
     @property

--- a/colin/utils/cont.py
+++ b/colin/utils/cont.py
@@ -81,8 +81,8 @@ class ImageName(object):
         name = "/".join(name_parts)
 
         if self.digest:
-            name += "@{}".format(self.digest)
+            name += f"@{self.digest}"
         elif self.tag:
-            name += ":{}".format(self.tag)
+            name += f":{self.tag}"
 
         return name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,11 +115,11 @@ def get_target(name, type):
 
 
 def get_skopeo_path(image_name, ostree_path):
-    return "ostree:%s@%s" % (image_name, ostree_path)
+    return f"ostree:{image_name}@{ostree_path}"
 
 
 def get_skopeo_oci_target(image_name, oci_path):
-    return "oci:%s:%s" % (oci_path, image_name)
+    return f"oci:{oci_path}:{image_name}"
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -78,5 +78,5 @@ def test_loading_custom_check(tmpdir):
 def test_import_class():
     check_loader = CheckLoader([])
     check_name = "ArchitectureLabelCheck"
-    imported_class = check_loader.import_class("colin.checks.labels.%s" % check_name)
+    imported_class = check_loader.import_class(f"colin.checks.labels.{check_name}")
     assert imported_class.name == "architecture_label"


### PR DESCRIPTION
* Use flynt to convert old forms of string templating.
* Use `%s` in logger and forward arguments.