### PR TITLE
Create a new `0.5.2` release that replaces the badly done `0.5.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
-# 0.5.1
+# 0.5.2
 
 ## Fixes
 
 - The global location of rulesests is now correctly found.
+
+# 0.5.1
+
+- Badly done release (version not updated everywhere).
+- Replaced by `0.5.2`.
 
 # 0.5.0
 

--- a/colin.spec
+++ b/colin.spec
@@ -9,7 +9,7 @@
 %endif
 
 Name:           %{pypi_name}
-Version:        0.5.1
+Version:        0.5.2
 Release:        1%{?dist}
 Summary:        Tool to check generic rules/best-practices for containers/images/dockerfiles.
 
@@ -77,6 +77,9 @@ rm -rf html/.{doctrees,buildinfo}
 %doc html
 
 %changelog
+* Wed Jan 12 09:32:57 CET 2022 Frantisek Lachman <flachman@redhat.com> - 0.5.2-1
+- New upstream release 0.5.2
+
 * Mon Jan 10 09:56:32 CET 2022 Frantisek Lachman <flachman@redhat.com> - 0.5.1-1
 - New upstream release 0.5.1
 

--- a/colin/version.py
+++ b/colin/version.py
@@ -14,4 +14,4 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-__version__ = "0.5.0"
+__version__ = "0.5.2"


### PR DESCRIPTION
We need to update version in the following places:
* `./colin/version.py`
* `./colin.spec` (`Version` tag and a new changelog entry)
* new changelog entry in `./CHANGELOG.md`

Signed-off-by: Frantisek Lachman <flachman@redhat.com>

Sorry for the mess with the previous release. I forgot to update `./colin/version.py` and the PyPI release failed because of that:
https://github.com/user-cont/colin/runs/4786572941?check_suite_focus=true