### PR TITLE
docs/list_of_checks: Formatting, ref sys.prefix

### DIFF
--- a/docs/list_of_checks.rst
+++ b/docs/list_of_checks.rst
@@ -48,7 +48,7 @@ and we can use them by name in other commands. (e.g. ``colin check -r fedora``).
 Colin can use ruleset-files in the following directories:
 
 - ``./rulesets/`` (subdirectory of the current working directory)
-- ``~/local/share/colin/rulesets/`` (user installation)
+- ``~/.local/share/colin/rulesets/`` (user installation)
 - `sys.prefix`_\ ``/share/colin/rulesets/`` (system-wide installation)
 
 .. _sys.prefix: https://docs.python.org/3/library/sys.html?highlight=sys%20prefix#sys.prefix

--- a/docs/list_of_checks.rst
+++ b/docs/list_of_checks.rst
@@ -31,8 +31,8 @@ we can define so-called rulesets, that defines:
     }
 
 
-Rulesets in the *standard* location can be shown with `colin list-rulesets`
-and we can use them by name in other commands. (e.g. `colin check -r fedora`).
+Rulesets in the *standard* location can be shown with ``colin list-rulesets``
+and we can use them by name in other commands. (e.g. ``colin check -r fedora``).
 
 .. code-block:: bash
 
@@ -47,9 +47,11 @@ and we can use them by name in other commands. (e.g. `colin check -r fedora`).
 
 Colin can use ruleset-files in the following directories:
 
-- `./rulesets/` (subdirectory of the current working directory)
-- `~/local/share/colin/rulesets/` (user installation)
-- `/usr/local/share/colin/rulesets/` (system-wide installation)
+- ``./rulesets/`` (subdirectory of the current working directory)
+- ``~/local/share/colin/rulesets/`` (user installation)
+- `sys.prefix`_\ ``/share/colin/rulesets/`` (system-wide installation)
+
+.. _sys.prefix: https://docs.python.org/3/library/sys.html?highlight=sys%20prefix#sys.prefix
 
 We can easily list the checks with the following command:
 


### PR DESCRIPTION
Now that #285 has fixed the hardcoding of `/usr/local/` in the code, this PR fixes it in the documentation. The fixed path is replaced with a hyperlinked `sys.prefix`, leading to the relevant section of the Python docs. I also corrected the user default path (`~/.local/...`, not `~/local/...`.)

While I was in there I noticed that the strings intended to be inline literals (I presume) weren't showing that way, because they were written using MarkDown syntax (\`single backtick\` fencing) rather than RST syntax (\`\`double backtick\`\` fencing), so I fixed those as well.