### PR TITLE
Add workaround for default instalation from PyPI

### DIFF
--- a/colin/core/ruleset/ruleset.py
+++ b/colin/core/ruleset/ruleset.py
@@ -216,10 +216,16 @@ def get_ruleset_dirs():
         logger.debug("Local ruleset directory found ('%s').", local_share)
         ruleset_dirs.append(local_share)
 
-    usr_local_share = os.path.join(sys.prefix, RULESET_DIRECTORY)
+    usr_local_share = os.path.join("/usr/local", RULESET_DIRECTORY)
     if os.path.isdir(usr_local_share):
         logger.debug("Global ruleset directory found ('%s').", usr_local_share)
         ruleset_dirs.append(usr_local_share)
+
+    if sys.prefix != "/usr/local":
+        global_share = os.path.join(sys.prefix, RULESET_DIRECTORY)
+        if os.path.isdir(global_share):
+            logger.debug("Global ruleset directory found ('%s').", global_share)
+            ruleset_dirs.append(global_share)
 
     if not ruleset_dirs:
         msg = "Ruleset directory cannot be found."

--- a/docs/list_of_checks.rst
+++ b/docs/list_of_checks.rst
@@ -49,6 +49,7 @@ Colin can use ruleset-files in the following directories:
 
 - ``./rulesets/`` (subdirectory of the current working directory)
 - ``~/.local/share/colin/rulesets/`` (user installation)
+- ``/usr/local/share/colin/rulesets/`` (system-wide installation if `sys.prefix` is not `/usr/local`)
 - `sys.prefix`_\ ``/share/colin/rulesets/`` (system-wide installation)
 
 .. _sys.prefix: https://docs.python.org/3/library/sys.html?highlight=sys%20prefix#sys.prefix


### PR DESCRIPTION
Running list-rulesets will fail for package installed from PyPI
```
[root@b04c448e74fc /]# dnf install -y -e0 -d0 podman python3-pip
//snip

[root@b04c448e74fc /]# pip install colin==0.5.2
//snip

[root@b04c448e74fc /]# python3 -c 'import colin; print(colin.__path__)'
['/usr/local/lib/python3.9/site-packages/colin']
[root@b04c448e74fc /]# ls -l /usr/local/share/colin/rulesets/
total 8
-rw-r--r--. 1 root root  582 Mar  1 16:52 default.json
-rw-r--r--. 1 root root 1611 Mar  1 16:52 fedora.json

[root@b04c448e74fc /]# /usr/local/bin/colin list-rulesets
Ruleset directory cannot be found.
An error occurred: ColinRulesetException('Ruleset directory cannot be found.')
Error: Ruleset directory cannot be found.
```
There does not seems to be any trivial and reliable way how to identify
where `data_files` are installed by setuptools. There are way how to get
pkg_data but that is something different.
Therefore I decided to special case `/usr/local`